### PR TITLE
Add responsive fade‑in animations and mobile typography

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -182,6 +182,25 @@ section {
     position: relative;
 }
 
+/* Reusable fade-in effect for section content */
+.fade-in {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity var(--transition-medium), transform var(--transition-medium);
+}
+
+.fade-in.in-view {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fade-in {
+        transition: none;
+        transform: none;
+    }
+}
+
 @keyframes fadeIn {
     from { opacity: 0; transform: translateY(20px); }
     to { opacity: 1; transform: translateY(0); }
@@ -414,7 +433,7 @@ nav ul li a.active:after {
     letter-spacing: -0.02em;
     font-weight: 700; /* keep real 700 weight */
     font-family: var(--font-heading);
-    font-size: 4rem;
+    font-size: clamp(2.5rem, 6vw, 4rem);
     line-height: 1.1;
     margin-bottom: 20px;
     background: linear-gradient(135deg, #E59D83, #C4B5ED);
@@ -431,6 +450,7 @@ nav ul li a.active:after {
 .hero h2 {
     animation: fadeInUp 1s ease-out 0.4s both;
     margin-bottom: 30px;
+    font-size: clamp(1.2rem, 3vw, 1.8rem);
 }
 
 .hero .cta-button {
@@ -1829,14 +1849,6 @@ footer::before {
         padding: 100px 0 80px;
     }
     
-    .hero h1 {
-        font-size: 3rem;
-    }
-    
-    .hero h2 {
-        font-size: 1.4rem;
-    }
-    
     /* Updated prize cards for mobile view */
     .prize-cards {
         flex-direction: column;
@@ -1964,14 +1976,6 @@ footer::before {
     .social-buttons {
         flex-direction: column;
         align-items: center;
-    }
-    
-    .hero h1 {
-        font-size: 2.5rem;
-    }
-    
-    .hero h2 {
-        font-size: 1.2rem;
     }
     
     .google-form-container {

--- a/js/main.js
+++ b/js/main.js
@@ -230,27 +230,20 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
-    // Add animation classes to elements when they become visible
-    const animateOnScroll = function() {
-        const elements = document.querySelectorAll('.card, .prize-card, .step, .judge-card, .prize, .contact-method');
-        
-        elements.forEach(element => {
-            const elementPosition = element.getBoundingClientRect();
-            
-            // Check if element is in viewport
-            if (elementPosition.top < window.innerHeight * 0.9 && elementPosition.bottom > 0) {
-                if (!element.classList.contains('animated')) {
-                    element.classList.add('animated');
-                    element.style.animation = 'fadeIn 0.8s ease forwards';
-                }
+    // Fade-in elements when they enter the viewport
+    const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('in-view');
+                obs.unobserve(entry.target);
             }
         });
-    };
-    
-    // Run on scroll and on load
-    window.addEventListener('scroll', animateOnScroll);
-    window.addEventListener('resize', animateOnScroll);
-    animateOnScroll(); // Run once on page load
+    }, { threshold: 0.1 });
+
+    document.querySelectorAll('section, .card, .prize-card, .step, .judge-card, .prize, .contact-method').forEach(el => {
+        el.classList.add('fade-in');
+        observer.observe(el);
+    });
     
     // Add special effects to prizes section
     const enhancePrizes = function() {


### PR DESCRIPTION
## Summary
- add reusable fade-in utility with reduced-motion fallback
- implement IntersectionObserver for on-scroll animations
- use fluid `clamp()` hero headings for better mobile display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c756d63b7c8330ba5cacde7bedb636