### PR TITLE
Refine mobile cookie consent layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2399,13 +2399,19 @@ footer::before {
 @media (max-width: 768px) {
     .cookie-consent {
         bottom: 16px;
-        padding: 18px;
+        padding: 16px;
         border-radius: 18px;
     }
 
     .cookie-consent__container {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: stretch;
+        gap: 16px;
+    }
+
+    .cookie-consent__content {
+        flex: 1 1 auto;
+        width: 100%;
     }
 
     .cookie-consent__actions {


### PR DESCRIPTION
## Summary
- adjust the cookie consent banner spacing on small screens to remove the oversized blank area
- ensure the content column fills the card while keeping buttons full width for easy tapping

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68cc5c80f8608330a4b57c56b5f57911