### PR TITLE
Move school highlights into Our Journey

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,8 +45,20 @@
             <ul>
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html" class="active">About</a></li>
+                <li class="has-submenu">
+                    <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
+                        Our Journey
+                        <span class="submenu-icon" aria-hidden="true"></span>
+                    </button>
+                    <ul class="submenu">
+                        <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                        <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                    </ul>
+                </li>
                 <li><a href="competition.html">Competition</a></li>
                 <li><a href="submission.html">Submit Your Art</a></li>
+                <li><a href="founders.html">Founders</a></li>
+                <li><a href="support.html">Support Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html">Privacy</a></li>
             </ul>
@@ -110,8 +122,11 @@
                     <ul class="quick-links-list" data-animate-group>
                         <li><a href="index.html" data-animate>Home</a></li>
                         <li><a href="about.html" data-animate>About</a></li>
+                        <li><a href="our-journey.html" data-animate>Our Journey</a></li>
                         <li><a href="competition.html" data-animate>Competition</a></li>
                         <li><a href="submission.html" data-animate>Submit Your Art</a></li>
+                        <li><a href="founders.html" data-animate>Founders</a></li>
+                        <li><a href="support.html" data-animate>Support Us</a></li>
                         <li><a href="contact.html" data-animate>Contact</a></li>
                         <li><a href="privacy.html" data-animate>Privacy Policy</a></li>
                     </ul>

--- a/competition.html
+++ b/competition.html
@@ -45,8 +45,20 @@
             <ul>
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
+                <li class="has-submenu">
+                    <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
+                        Our Journey
+                        <span class="submenu-icon" aria-hidden="true"></span>
+                    </button>
+                    <ul class="submenu">
+                        <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                        <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                    </ul>
+                </li>
                 <li><a href="competition.html" class="active">Competition</a></li>
                 <li><a href="submission.html">Submit Your Art</a></li>
+                <li><a href="founders.html">Founders</a></li>
+                <li><a href="support.html">Support Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html">Privacy</a></li>
             </ul>
@@ -217,8 +229,11 @@
                     <ul class="quick-links-list" data-animate-group>
                         <li><a href="index.html" data-animate>Home</a></li>
                         <li><a href="about.html" data-animate>About</a></li>
+                        <li><a href="our-journey.html" data-animate>Our Journey</a></li>
                         <li><a href="competition.html" data-animate>Competition</a></li>
                         <li><a href="submission.html" data-animate>Submit Your Art</a></li>
+                        <li><a href="founders.html" data-animate>Founders</a></li>
+                        <li><a href="support.html" data-animate>Support Us</a></li>
                         <li><a href="contact.html" data-animate>Contact</a></li>
                         <li><a href="privacy.html" data-animate>Privacy Policy</a></li>
                     </ul>

--- a/css/style.css
+++ b/css/style.css
@@ -487,6 +487,7 @@ header .container {
 
 nav ul li {
     margin-left: 20px;
+    position: relative;
 }
 
 nav.collapsed {
@@ -501,7 +502,8 @@ nav ul {
     margin: 0;
 }
 
-nav ul li a {
+nav ul li > a,
+nav ul li > .submenu-toggle {
     padding: 10px 5px;
     font-weight: 600; /* Increased from 500 for better visibility */
     position: relative;
@@ -510,10 +512,26 @@ nav ul li a {
     letter-spacing: 0.02em;
     color: var(--dark-color);
     transition: color 0.2s ease, transform 0.2s ease;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
 }
 
-nav ul li a:after {
+nav ul li > .submenu-toggle {
+    font: inherit;
+}
+
+nav ul li > .submenu-toggle:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 4px;
+    border-radius: 6px;
+}
+
+nav ul li > a:after {
     content: '';
     position: absolute;
     bottom: 0;
@@ -524,14 +542,98 @@ nav ul li a:after {
     transition: width var(--transition-medium);
 }
 
-nav ul li a:hover {
+nav ul li > a:hover,
+nav ul li > .submenu-toggle:hover,
+nav ul li > .submenu-toggle:focus-visible {
     color: var(--primary-color);
     transform: translateY(-2px);
 }
 
-nav ul li a:hover:after,
-nav ul li a.active:after {
+nav ul li > a:hover:after,
+nav ul li > a.active:after {
     width: 100%;
+}
+
+nav ul li > .submenu-toggle.active,
+nav ul li.has-submenu.open > .submenu-toggle,
+nav ul li.has-submenu:focus-within > .submenu-toggle {
+    color: var(--primary-color);
+}
+
+nav ul li > .submenu-toggle .submenu-icon {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-left: 4px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid currentColor;
+    transition: transform 0.2s ease;
+    transform-origin: center;
+}
+
+nav ul li.has-submenu:hover > .submenu-toggle .submenu-icon,
+nav ul li.has-submenu.open > .submenu-toggle .submenu-icon,
+nav ul li.has-submenu:focus-within > .submenu-toggle .submenu-icon {
+    transform: rotate(180deg);
+}
+
+nav ul li .submenu {
+    position: absolute;
+    top: calc(100% + 12px);
+    left: 0;
+    background: var(--white);
+    list-style: none;
+    padding: 12px 0;
+    margin: 0;
+    border-radius: 14px;
+    box-shadow: var(--box-shadow);
+    min-width: 280px;
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity var(--transition-medium), transform var(--transition-medium);
+    pointer-events: none;
+    z-index: 1000;
+}
+
+nav ul li .submenu li {
+    margin: 0;
+    border: none;
+    animation: none;
+}
+
+nav ul li .submenu a {
+    display: block;
+    padding: 10px 20px;
+    font-weight: 500;
+    font-size: 0.95rem;
+    color: var(--dark-color);
+    text-decoration: none;
+    transition: background var(--transition-medium), color var(--transition-medium);
+    white-space: normal;
+    line-height: 1.5;
+}
+
+nav ul li .submenu a:hover,
+nav ul li .submenu a:focus {
+    background-color: var(--peach-light);
+    color: var(--primary-color);
+}
+
+nav ul li .submenu a.active {
+    background-color: rgba(229, 157, 131, 0.12);
+    color: var(--primary-color);
+    font-weight: 600;
+}
+
+nav ul li.has-submenu:hover > .submenu,
+nav ul li.has-submenu.open > .submenu,
+nav ul li.has-submenu:focus-within > .submenu {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 /* Hero Section */
@@ -1937,6 +2039,466 @@ footer::before {
     margin-right: 8px;
 }
 
+/* Our Journey Sections */
+.journey-intro {
+    background: var(--peach-light);
+    padding: 80px 0;
+    text-align: center;
+}
+
+.journey-intro p {
+    max-width: 720px;
+    margin: 20px auto 0;
+    color: var(--text-muted);
+}
+
+.journey-section {
+    padding: 80px 0;
+    scroll-margin-top: 120px;
+}
+
+.journey-section--alt {
+    background: var(--light-color);
+}
+
+.journey-header {
+    max-width: 760px;
+    margin: 0 auto 32px;
+    text-align: center;
+}
+
+.journey-header h2 {
+    margin-bottom: 12px;
+}
+
+.journey-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
+}
+
+.journey-subsection {
+    margin-top: 56px;
+}
+
+.journey-subsection h3 {
+    font-family: var(--font-heading);
+    text-align: center;
+    margin-bottom: 12px;
+}
+
+.journey-subsection-lead {
+    max-width: 760px;
+    margin: 0 auto 28px;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.journey-subsection--team .team-grid,
+.journey-subsection--winners .winner-grid {
+    margin-top: 32px;
+}
+
+.journey-card {
+    background: var(--white);
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: var(--box-shadow);
+    border: 1px solid rgba(0, 0, 0, 0.04);
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
+}
+
+.journey-card:hover,
+.journey-card:focus-within {
+    transform: translateY(-6px);
+    box-shadow: var(--box-shadow-hover);
+}
+
+.journey-card h3 {
+    font-family: var(--font-heading);
+    margin-bottom: 12px;
+    color: var(--secondary-color);
+}
+
+.journey-card p {
+    color: var(--text-muted);
+}
+
+.journey-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 16px 0 0 0;
+    display: grid;
+    gap: 10px;
+}
+
+.journey-card ul li {
+    position: relative;
+    padding-left: 20px;
+    color: var(--text-muted);
+}
+
+.journey-card ul li::before {
+    content: '•';
+    position: absolute;
+    left: 0;
+    color: var(--primary-color);
+    font-size: 1.2rem;
+    line-height: 1;
+    top: -2px;
+}
+
+.journey-callout {
+    margin-top: 32px;
+    background: linear-gradient(135deg, rgba(229, 157, 131, 0.18), rgba(122, 184, 204, 0.18));
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: var(--box-shadow);
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.journey-callout .journey-actions {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-top: 18px;
+}
+
+@media (max-width: 768px) {
+    .journey-section {
+        padding: 60px 0;
+        scroll-margin-top: 96px;
+    }
+
+    .journey-subsection {
+        margin-top: 44px;
+    }
+
+    .journey-subsection-lead {
+        margin-bottom: 24px;
+    }
+
+}
+
+/* Team & Profile Cards */
+.team-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+    margin-top: 28px;
+}
+
+.team-card {
+    background: var(--white);
+    border-radius: 16px;
+    padding: 24px;
+    text-align: center;
+    box-shadow: var(--box-shadow);
+    border: 1px solid rgba(0, 0, 0, 0.04);
+    border-top: 4px solid rgba(229, 157, 131, 0.2);
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
+}
+
+.team-card:hover,
+.team-card:focus-within {
+    transform: translateY(-6px);
+    box-shadow: var(--box-shadow-hover);
+}
+
+.team-card.coordinator {
+    border-top-color: var(--secondary-color);
+}
+
+.team-card.judge {
+    border-top-color: var(--accent-color);
+}
+
+.team-card.founder-card {
+    border-top-color: var(--primary-color);
+}
+
+.team-photo {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    background: var(--peach-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 16px;
+    border: 3px solid rgba(229, 157, 131, 0.25);
+    overflow: hidden;
+}
+
+.team-photo img {
+    width: 64px;
+    height: auto;
+}
+
+.team-card h3,
+.team-card h4 {
+    font-size: 1.2rem;
+    margin-bottom: 8px;
+}
+
+.team-role {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--secondary-color);
+    display: inline-block;
+    margin-bottom: 12px;
+}
+
+.team-card p {
+    color: var(--text-muted);
+    font-size: 0.96rem;
+    line-height: 1.6;
+}
+
+/* Competition Team & Winners */
+.competition-team {
+    padding: 80px 0;
+    background: var(--peach-light);
+}
+
+.competition-team .section-lead {
+    max-width: 760px;
+    margin: 0 auto;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.competition-team .team-wrapper {
+    margin-top: 48px;
+}
+
+.team-wrapper + .team-wrapper {
+    margin-top: 64px;
+}
+
+.team-wrapper h3 {
+    text-align: center;
+    margin-bottom: 16px;
+}
+
+.competition-winners {
+    padding: 80px 0;
+}
+
+.competition-winners .section-lead {
+    max-width: 760px;
+    margin: 0 auto;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.winners-group {
+    margin-top: 48px;
+}
+
+.winners-group + .winners-group {
+    margin-top: 56px;
+}
+
+.winners-group h3 {
+    text-align: center;
+    margin-bottom: 12px;
+}
+
+.winner-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+    margin-top: 24px;
+}
+
+.winner-card {
+    background: var(--white);
+    border-radius: 16px;
+    padding: 20px;
+    text-align: center;
+    box-shadow: var(--box-shadow);
+    border: 1px solid rgba(0, 0, 0, 0.04);
+    border-top: 4px solid var(--accent-color);
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
+}
+
+.winner-card:hover,
+.winner-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: var(--box-shadow-hover);
+}
+
+.winner-card.first-place {
+    border-top-color: var(--gold);
+}
+
+.winner-card.second-place {
+    border-top-color: var(--silver);
+}
+
+.winner-card.third-place {
+    border-top-color: var(--bronze);
+}
+
+.winner-card.honorable-mention {
+    border-top-color: var(--accent-secondary);
+}
+
+.winner-card h4 {
+    margin-bottom: 8px;
+    font-size: 1.15rem;
+}
+
+.winner-card p {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.winner-image {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--peach-light);
+    margin-bottom: 16px;
+}
+
+.winner-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.image-placeholder {
+    border: 2px dashed rgba(122, 184, 204, 0.5);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--secondary-color);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 18px;
+    font-size: 0.85rem;
+}
+
+/* Support Page */
+.support-page {
+    padding: 80px 0;
+    background: var(--light-color);
+}
+
+.support-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 40px;
+    align-items: flex-start;
+}
+
+.support-text {
+    background: var(--white);
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: var(--box-shadow);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.support-text p {
+    color: var(--text-muted);
+    margin-top: 16px;
+}
+
+.support-list {
+    list-style: none;
+    padding: 0;
+    margin: 20px 0 0 0;
+    display: grid;
+    gap: 12px;
+}
+
+.support-list li {
+    position: relative;
+    padding-left: 22px;
+    color: var(--text-muted);
+}
+
+.support-list li::before {
+    content: '✔';
+    position: absolute;
+    left: 0;
+    color: var(--primary-color);
+    font-size: 0.9rem;
+    top: 2px;
+}
+
+.support-actions {
+    padding: 80px 0;
+}
+
+.support-actions h2 {
+    text-align: center;
+}
+
+.support-actions p {
+    max-width: 720px;
+    margin: 12px auto 0;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.support-actions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 24px;
+    margin-top: 32px;
+}
+
+.support-card {
+    background: var(--white);
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: var(--box-shadow);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
+}
+
+.support-card:hover,
+.support-card:focus-within {
+    transform: translateY(-6px);
+    box-shadow: var(--box-shadow-hover);
+}
+
+.support-card h3 {
+    margin-bottom: 12px;
+    color: var(--secondary-color);
+}
+
+.support-card p {
+    color: var(--text-muted);
+}
+
+.support-cta {
+    padding: 80px 0;
+    background: var(--peach-light);
+    text-align: center;
+}
+
+.support-cta p {
+    max-width: 640px;
+    margin: 16px auto 24px;
+    color: var(--text-muted);
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     .nav-toggle {
@@ -1985,21 +2547,24 @@ footer::before {
         border-bottom: 1px solid rgba(0,0,0,0.05);
         padding: 4px 0;
     }
-    
-        nav.expanded ul li:nth-child(1) { animation-delay: 0.1s; }
+
+    nav.expanded ul li:nth-child(1) { animation-delay: 0.1s; }
     nav.expanded ul li:nth-child(2) { animation-delay: 0.15s; }
     nav.expanded ul li:nth-child(3) { animation-delay: 0.2s; }
     nav.expanded ul li:nth-child(4) { animation-delay: 0.25s; }
     nav.expanded ul li:nth-child(5) { animation-delay: 0.3s; }
     nav.expanded ul li:nth-child(6) { animation-delay: 0.35s; }
     nav.expanded ul li:nth-child(7) { animation-delay: 0.4s; }
-    
+    nav.expanded ul li:nth-child(8) { animation-delay: 0.45s; }
+    nav.expanded ul li:nth-child(9) { animation-delay: 0.5s; }
+
     @keyframes fadeInMenuItem {
         from { opacity: 0; transform: translateX(-20px); }
         to { opacity: 1; transform: translateX(0); }
     }
-    
-    nav ul li a {
+
+    nav ul li > a,
+    nav ul li > .submenu-toggle {
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -2012,22 +2577,70 @@ footer::before {
         font-size: 1.1rem;
         font-weight: 500;
     }
-    
-    nav ul li a:hover {
+
+    nav ul li > .submenu-toggle {
+        text-align: left;
+    }
+
+    nav ul li > a:hover,
+    nav ul li > .submenu-toggle:hover,
+    nav ul li > .submenu-toggle:focus-visible {
         background-color: rgba(0,0,0,0.03);
         color: var(--primary-color);
     }
-    
+
     /* Remove arrows from mobile navigation */
-    @media (max-width: 992px) {
-        nav ul li a::after {
-            display: none;
-        }
+    nav ul li > a::after {
+        display: none;
     }
-    
-    nav ul li a:hover::after {
+
+    nav ul li > a:hover::after {
         transform: translateX(4px);
         opacity: 0.8;
+    }
+
+    nav ul li .submenu {
+        position: static;
+        background: transparent;
+        box-shadow: none;
+        padding: 0 0 0 12px;
+        margin-top: 0;
+        visibility: visible;
+        opacity: 1;
+        transform: none;
+        max-height: 0;
+        overflow: hidden;
+        pointer-events: none;
+        transition: max-height 0.3s ease;
+    }
+
+    nav ul li.has-submenu.open > .submenu {
+        max-height: 600px;
+        pointer-events: auto;
+        margin-top: 8px;
+    }
+
+    nav ul li .submenu li {
+        margin-bottom: 8px;
+        padding: 0;
+        border: none;
+        animation: none;
+    }
+
+    nav ul li .submenu a {
+        padding: 10px 12px;
+        border-radius: 6px;
+        background: rgba(255, 255, 255, 0.65);
+        font-size: 1rem;
+    }
+
+    nav ul li .submenu a:hover,
+    nav ul li .submenu a:focus {
+        background: rgba(229, 157, 131, 0.12);
+    }
+
+    nav ul li > .submenu-toggle .submenu-icon {
+        margin-left: auto;
     }
     
     /* Animation for the hamburger icon */

--- a/founders.html
+++ b/founders.html
@@ -3,14 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact Us | Artists of Tomorrow</title>
-    <meta name="description" content="Get in touch with the Artists of Tomorrow team">
-    
+    <title>Our Founders | Artists of Tomorrow</title>
+    <meta name="description" content="Meet the founders of Artists of Tomorrow and learn about their commitment to creative youth.">
+
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
-
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){
@@ -25,20 +22,9 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-    
+
       gtag('config', 'G-K8P4HJ9KY3');
     </script>
-    
-    <style>
-        /* Social media row hover effect */
-        .social-row:hover {
-            transform: translateX(5px);
-        }
-        
-        .social-row:hover a {
-            color: var(--primary-color);
-        }
-    </style>
 </head>
 <body>
     <header>
@@ -54,74 +40,76 @@
                 <span></span>
                 <span></span>
             </div>
-        <nav id="mainNav" class="collapsed">
-            <ul>
-                <li><a href="index.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li class="has-submenu">
-                    <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
-                        Our Journey
-                        <span class="submenu-icon" aria-hidden="true"></span>
-                    </button>
-                    <ul class="submenu">
-                        <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
-                        <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
-                    </ul>
-                </li>
-                <li><a href="competition.html">Competition</a></li>
-                <li><a href="submission.html">Submit Your Art</a></li>
-                <li><a href="founders.html">Founders</a></li>
-                <li><a href="support.html">Support Us</a></li>
-                <li><a href="contact.html" class="active">Contact</a></li>
-                <li><a href="privacy.html">Privacy</a></li>
-            </ul>
-        </nav>
+            <nav id="mainNav" class="collapsed">
+                <ul>
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="about.html">About</a></li>
+                    <li class="has-submenu">
+                        <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
+                            Our Journey
+                            <span class="submenu-icon" aria-hidden="true"></span>
+                        </button>
+                        <ul class="submenu">
+                            <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                            <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="competition.html">Competition</a></li>
+                    <li><a href="submission.html">Submit Your Art</a></li>
+                    <li><a href="founders.html" class="active">Founders</a></li>
+                    <li><a href="support.html">Support Us</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                    <li><a href="privacy.html">Privacy</a></li>
+                </ul>
+            </nav>
         </div>
-</header>
+    </header>
 
     <main class="page-content">
         <section class="page-header">
             <div class="container" data-animate>
-                <h1>Contact Us</h1>
+                <h1>Our Founders</h1>
             </div>
         </section>
 
-        <section class="contact-info" id="contact">
+        <section class="journey-intro">
             <div class="container" data-animate>
-                <div class="contact-container" data-animate>
-                    <div class="contact-details">
-                        <h2>Get In Touch</h2>
-                        <p>Have questions about the competition? Interested in supporting our mission? We'd love to hear from you!</p>
+                <p>The founders of Artists of Tomorrow are united by a shared belief that creativity should be celebrated in every classroom. Their leadership guides each program, competition, and partnership that we build.</p>
+            </div>
+        </section>
 
-                        <div class="contact-methods" data-animate-group>
-                            <div class="contact-method" data-animate>
-                                <h3>Email</h3>
-                                <p class="email-address">
-                                    <a href="mailto:info.artistsoftomorrow@gmail.com">info.artistsoftomorrow@gmail.com</a>
-                                </p>
-                            </div>
-                            <div class="contact-method" data-animate>
-                                <h3>Social Media</h3>
-                                <div class="social-row" data-animate>
-                                    <img src="images/instagram-icon.png" alt="Instagram">
-                                    <a href="https://www.instagram.com/artists.0f.tomorrow/" target="_blank" rel="noopener noreferrer">@artists.0f.tomorrow</a>
-                                </div>
-                                <div class="social-row" data-animate>
-                                    <img src="images/tiktok-icon.png" alt="TikTok">
-                                    <a href="https://www.tiktok.com/@artists.of.tomorrow" target="_blank" rel="noopener noreferrer">@artists.of.tomorrow</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+        <section class="journey-section">
+            <div class="container">
+                <div class="journey-header" data-animate>
+                    <h2>Meet the Team Behind the Vision</h2>
+                    <p>These profiles are placeholders&mdash;replace them with the stories, achievements, and aspirations of our founding team.</p>
                 </div>
-            </div>
-        </section>
-
-        <section class="support-cta">
-            <div class="container" data-animate>
-                <h2>Support Our Mission</h2>
-                <p>Artists of Tomorrow relies on the generous support of donors and volunteers to make our competition possible and provide art supplies to participating students.</p>
-                <a href="support.html" class="cta-button">Visit Support Us</a>
+                <div class="team-grid" data-animate-group>
+                    <article class="team-card founder-card" data-animate>
+                        <div class="team-photo">
+                            <img src="images/logo.svg" alt="Placeholder portrait for Anish Batra">
+                        </div>
+                        <h3>Anish Batra</h3>
+                        <p class="team-role">Co-Founder</p>
+                        <p>Anish Batra co-founded Artists of Tomorrow to expand creative opportunities for students in Nathupur. Replace this placeholder biography with highlights from Anish's story and the initiatives he leads.</p>
+                    </article>
+                    <article class="team-card founder-card" data-animate>
+                        <div class="team-photo">
+                            <img src="images/logo.svg" alt="Placeholder portrait for Amishi Batra">
+                        </div>
+                        <h3>Amishi Batra</h3>
+                        <p class="team-role">Co-Founder</p>
+                        <p>Amishi Batra champions inclusive arts education and community storytelling. Swap in the milestones, inspirations, and impact that define Amishi's journey with Artists of Tomorrow.</p>
+                    </article>
+                    <article class="team-card founder-card" data-animate>
+                        <div class="team-photo">
+                            <img src="images/logo.svg" alt="Placeholder portrait for Mishika Jain">
+                        </div>
+                        <h3>Mishika Jain</h3>
+                        <p class="team-role">Co-Founder</p>
+                        <p>Mishika Jain brings a passion for student advocacy and creative mentorship to the organization. Update this space with Mishika's accomplishments and the vision they bring to future competitions.</p>
+                    </article>
+                </div>
             </div>
         </section>
     </main>
@@ -170,6 +158,7 @@
             </div>
         </div>
     </footer>
+
     <script src="js/main.js"></script>
     <script src="js/privacy-notice.js"></script>
     <script src="js/clarity-helper.js"></script>

--- a/index.html
+++ b/index.html
@@ -44,8 +44,20 @@
             <ul>
                 <li><a href="index.html" class="active">Home</a></li>
                 <li><a href="about.html">About</a></li>
+                <li class="has-submenu">
+                    <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
+                        Our Journey
+                        <span class="submenu-icon" aria-hidden="true"></span>
+                    </button>
+                    <ul class="submenu">
+                        <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                        <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                    </ul>
+                </li>
                 <li><a href="competition.html">Competition</a></li>
                 <li><a href="submission.html">Submit Your Art</a></li>
+                <li><a href="founders.html">Founders</a></li>
+                <li><a href="support.html">Support Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html">Privacy</a></li>
             </ul>
@@ -146,8 +158,11 @@
                     <ul class="quick-links-list" data-animate-group>
                         <li><a href="index.html" data-animate>Home</a></li>
                         <li><a href="about.html" data-animate>About</a></li>
+                        <li><a href="our-journey.html" data-animate>Our Journey</a></li>
                         <li><a href="competition.html" data-animate>Competition</a></li>
                         <li><a href="submission.html" data-animate>Submit Your Art</a></li>
+                        <li><a href="founders.html" data-animate>Founders</a></li>
+                        <li><a href="support.html" data-animate>Support Us</a></li>
                         <li><a href="contact.html" data-animate>Contact</a></li>
                         <li><a href="privacy.html" data-animate>Privacy Policy</a></li>
                     </ul>

--- a/js/main.js
+++ b/js/main.js
@@ -81,30 +81,119 @@ document.addEventListener('DOMContentLoaded', function() {
     const mainNav = document.getElementById('mainNav');
     
     if (navToggle && mainNav) {
+        const submenuToggles = mainNav.querySelectorAll('.submenu-toggle');
+
+        const openActiveSubmenu = () => {
+            const activeSubLink = mainNav.querySelector('.submenu a[aria-current="page"], .submenu a.active');
+            if (!activeSubLink) {
+                return;
+            }
+
+            const parentItem = activeSubLink.closest('.has-submenu');
+            if (!parentItem) {
+                return;
+            }
+
+            parentItem.classList.add('open');
+
+            const activeToggle = parentItem.querySelector('.submenu-toggle');
+            if (activeToggle) {
+                activeToggle.setAttribute('aria-expanded', 'true');
+                activeToggle.classList.add('active');
+            }
+        };
+
+        const closeAllSubmenus = () => {
+            submenuToggles.forEach(toggle => {
+                const parentItem = toggle.closest('.has-submenu');
+                if (parentItem) {
+                    parentItem.classList.remove('open');
+                }
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        };
+
+        submenuToggles.forEach(toggle => {
+            toggle.setAttribute('aria-expanded', toggle.getAttribute('aria-expanded') === 'true' ? 'true' : 'false');
+
+            toggle.addEventListener('click', function(event) {
+                event.stopPropagation();
+                const parentItem = toggle.closest('.has-submenu');
+                const isOpen = parentItem.classList.toggle('open');
+                toggle.setAttribute('aria-expanded', isOpen);
+
+                submenuToggles.forEach(otherToggle => {
+                    if (otherToggle !== toggle) {
+                        const otherParent = otherToggle.closest('.has-submenu');
+                        if (otherParent) {
+                            otherParent.classList.remove('open');
+                        }
+                        otherToggle.setAttribute('aria-expanded', 'false');
+                    }
+                });
+
+                if (isOpen) {
+                    const firstSubLink = parentItem.querySelector('.submenu a');
+                    if (firstSubLink) {
+                        firstSubLink.focus();
+                    }
+                } else {
+                    toggle.focus();
+                }
+            });
+
+            toggle.addEventListener('keydown', function(event) {
+                if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    const parentItem = toggle.closest('.has-submenu');
+                    if (!parentItem.classList.contains('open')) {
+                        closeAllSubmenus();
+                        parentItem.classList.add('open');
+                        toggle.setAttribute('aria-expanded', 'true');
+                    }
+                    const firstSubLink = parentItem.querySelector('.submenu a');
+                    if (firstSubLink) {
+                        firstSubLink.focus();
+                    }
+                }
+
+                if (event.key === 'Escape') {
+                    const parentItem = toggle.closest('.has-submenu');
+                    if (parentItem && parentItem.classList.contains('open')) {
+                        parentItem.classList.remove('open');
+                        toggle.setAttribute('aria-expanded', 'false');
+                        toggle.focus();
+                    }
+                }
+            });
+        });
+
         // Close menu when a nav link is clicked (for mobile)
         const navLinks = mainNav.querySelectorAll('a');
         
         navToggle.addEventListener('click', function() {
             const isExpanded = mainNav.classList.toggle('expanded');
             navToggle.classList.toggle('active');
-            
+
             // Toggle body scroll
             document.body.style.overflow = isExpanded ? 'hidden' : '';
-            
+
             // Accessibility
             navToggle.setAttribute('aria-expanded', isExpanded);
-            
+
             // Focus management
             if (isExpanded) {
+                openActiveSubmenu();
                 // Move focus to first nav item when opening
                 const firstNavItem = mainNav.querySelector('a');
                 if (firstNavItem) firstNavItem.focus();
             } else {
                 // Return focus to menu button when closing
                 navToggle.focus();
+                closeAllSubmenus();
             }
         });
-        
+
         // Close menu when clicking on a nav link (for single page navigation)
         navLinks.forEach(link => {
             link.addEventListener('click', function() {
@@ -113,26 +202,30 @@ document.addEventListener('DOMContentLoaded', function() {
                     navToggle.classList.remove('active');
                     document.body.style.overflow = '';
                     navToggle.setAttribute('aria-expanded', 'false');
+                    closeAllSubmenus();
                 }
             });
         });
-        
+
         // Close menu when pressing Escape key
         document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && mainNav.classList.contains('expanded')) {
-                mainNav.classList.remove('expanded');
-                navToggle.classList.remove('active');
-                document.body.style.overflow = '';
-                navToggle.setAttribute('aria-expanded', 'false');
-                navToggle.focus();
+            if (e.key === 'Escape') {
+                if (mainNav.classList.contains('expanded')) {
+                    mainNav.classList.remove('expanded');
+                    navToggle.classList.remove('active');
+                    document.body.style.overflow = '';
+                    navToggle.setAttribute('aria-expanded', 'false');
+                    navToggle.focus();
+                }
+                closeAllSubmenus();
             }
         });
-        
+
         // Add accessibility attributes
         navToggle.setAttribute('aria-label', 'Toggle navigation menu');
         navToggle.setAttribute('aria-expanded', 'false');
         navToggle.setAttribute('aria-controls', 'mainNav');
-        
+
         // Add tab trapping for better keyboard navigation
         const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
         const focusableContent = mainNav.querySelectorAll(focusableElements);
@@ -159,18 +252,22 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             });
         }
+
+        document.addEventListener('click', function(event) {
+            const clickInsideNav = event.target.closest('nav');
+            const clickOnToggle = event.target.closest('.nav-toggle');
+
+            if (!event.target.closest('.has-submenu')) {
+                closeAllSubmenus();
+            }
+
+            if (mainNav.classList.contains('expanded') && !clickInsideNav && !clickOnToggle) {
+                mainNav.classList.remove('expanded');
+                navToggle.classList.remove('active');
+                navToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
     }
-    
-    // Close menu when clicking outside
-    document.addEventListener('click', function(event) {
-        if (mainNav && mainNav.classList.contains('expanded') && 
-            !event.target.closest('nav') && 
-            !event.target.closest('.nav-toggle')) {
-            mainNav.classList.remove('expanded');
-            navToggle.classList.remove('active');
-            navToggle.setAttribute('aria-expanded', 'false');
-        }
-    });
 
     // Registration form handling
     const registrationForm = document.getElementById('registrationForm');
@@ -186,9 +283,14 @@ document.addEventListener('DOMContentLoaded', function() {
             
             // Show the upload section
             const uploadSection = document.getElementById('uploadSection');
+            const submissionNumberField = document.getElementById('submissionNumber');
+
             if (uploadSection) {
                 uploadSection.classList.remove('hidden');
-                document.getElementById('submissionNumber').value = submissionNumber;
+            }
+
+            if (submissionNumberField) {
+                submissionNumberField.value = submissionNumber;
             }
         });
     }

--- a/our-journey.html
+++ b/our-journey.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Our Journey | Artists of Tomorrow</title>
+    <meta name="description" content="Discover how Artists of Tomorrow partners with schools in Nathupur to uplift young artists.">
+
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/style.css">
+
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "scsvrz0zyk");
+    </script>
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-K8P4HJ9KY3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-K8P4HJ9KY3');
+    </script>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">
+                <a href="index.html">
+                    <img src="images/logo.svg" alt="Artists of Tomorrow Logo">
+                    <span>Artists of Tomorrow</span>
+                </a>
+            </div>
+            <div class="nav-toggle" id="navToggle">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <nav id="mainNav" class="collapsed">
+                <ul>
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="about.html">About</a></li>
+                    <li class="has-submenu">
+                        <button class="submenu-toggle active" type="button" aria-expanded="false" aria-haspopup="true">
+                            Our Journey
+                            <span class="submenu-icon" aria-hidden="true"></span>
+                        </button>
+                        <ul class="submenu">
+                            <li><a href="#middle-school" class="active" aria-current="page">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                            <li><a href="#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="competition.html">Competition</a></li>
+                    <li><a href="submission.html">Submit Your Art</a></li>
+                    <li><a href="founders.html">Founders</a></li>
+                    <li><a href="support.html">Support Us</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                    <li><a href="privacy.html">Privacy</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main class="page-content">
+        <section class="page-header">
+            <div class="container" data-animate>
+                <h1>Our Journey in Nathupur</h1>
+            </div>
+        </section>
+
+        <section class="journey-intro">
+            <div class="container" data-animate>
+                <p>Artists of Tomorrow partners with schools in Nathupur to create vibrant, student-centered art programs. Together with educators, community leaders, and volunteers, we design spaces where every young person can explore creativity, practice storytelling, and feel seen.</p>
+            </div>
+        </section>
+
+        <section class="journey-section" id="middle-school">
+            <div class="container">
+                <div class="journey-header" data-animate>
+                    <h2>Government Senior Secondary School, Nathupur &mdash; Middle School</h2>
+                    <p>The middle school partnership focuses on giving emerging artists the confidence to experiment, reflect, and share their unique perspectives.</p>
+                </div>
+                <div class="journey-grid" data-animate-group>
+                    <article class="journey-card" data-animate>
+                        <h3>Program Snapshot</h3>
+                        <p>Grounded in playful exploration, the middle school program introduces foundational art and writing practices.</p>
+                        <ul>
+                            <li>Launch year: 2024 with 120+ student artists engaged.</li>
+                            <li>Weekly studio sessions emphasizing drawing, storytelling, and reflection.</li>
+                            <li>Family showcases that invite caregivers to celebrate student growth.</li>
+                        </ul>
+                    </article>
+                    <article class="journey-card" data-animate>
+                        <h3>Student Highlights</h3>
+                        <p>Students collaborate in small cohorts that foster empathy and positive feedback.</p>
+                        <ul>
+                            <li>Peer critique circles where artists practice sharing encouragement and constructive notes.</li>
+                            <li>Writing prompts that center movement, community, and personal identity.</li>
+                            <li>Mini-exhibitions curated by students to spotlight classmates' sketches and stories.</li>
+                        </ul>
+                    </article>
+                    <article class="journey-card" data-animate>
+                        <h3>What's Next</h3>
+                        <p>Next season, we are expanding resources so every student can document their creative journey.</p>
+                        <ul>
+                            <li>Introduce sketchbook libraries and archival folders for every participant.</li>
+                            <li>Offer peer-mentor roles for returning artists to support new students.</li>
+                            <li>Launch bilingual reflection guides for students and families.</li>
+                        </ul>
+                    </article>
+                </div>
+                <div class="journey-subsection journey-subsection--team" data-animate>
+                    <h3>Competition Team</h3>
+                    <p class="journey-subsection-lead">Meet the event coordinator and judges championing the middle school division.</p>
+                    <div class="team-grid" data-animate-group>
+                        <article class="team-card coordinator" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Poonam Yadav">
+                            </div>
+                            <h4>Poonam Yadav</h4>
+                            <p class="team-role">Event Coordinator &middot; Middle School Division</p>
+                            <p>Poonam Yadav coordinates the middle school division to keep every deadline, supply delivery, and celebration on track. Replace this placeholder bio with Poonam's story and the ways she champions each young artist.</p>
+                        </article>
+                        <article class="team-card judge" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Vandana Kothari">
+                            </div>
+                            <h4>Vandana Kothari</h4>
+                            <p class="team-role">Judge &middot; Middle School Panel</p>
+                            <p>Vandana Kothari lends a curator's eye to the middle school panel and encourages students to take bold creative risks. Replace this text with Vandana's achievements and mentoring experience.</p>
+                        </article>
+                        <article class="team-card judge" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Deepak">
+                            </div>
+                            <h4>Deepak</h4>
+                            <p class="team-role">Judge &middot; Middle School Panel</p>
+                            <p>Deepak offers thoughtful feedback that helps middle school artists connect technique with storytelling. Replace this placeholder with Deepak's background and the perspective he brings to the jury.</p>
+                        </article>
+                        <article class="team-card judge" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Shweta">
+                            </div>
+                            <h4>Shweta</h4>
+                            <p class="team-role">Judge &middot; Middle School Panel</p>
+                            <p>Shweta highlights the heart behind each submission and celebrates collaborative spirit across the middle school entries. Update this placeholder with Shweta's artistic journey and judging insights.</p>
+                        </article>
+                    </div>
+                </div>
+                <div class="journey-subsection journey-subsection--winners" data-animate>
+                    <h3>Winner Gallery</h3>
+                    <p class="journey-subsection-lead">Replace these placeholders with photos and celebrations for your middle school winners.</p>
+                    <div class="winner-grid" data-animate-group>
+                        <article class="winner-card first-place" data-animate>
+                            <div class="winner-image image-placeholder">Add 1st Place Photo</div>
+                            <h4>1st Place</h4>
+                            <p>Share the winner's name, artwork title, and a short celebration of their piece here.</p>
+                        </article>
+                        <article class="winner-card second-place" data-animate>
+                            <div class="winner-image image-placeholder">Add 2nd Place Photo</div>
+                            <h4>2nd Place</h4>
+                            <p>Use this placeholder to highlight the second-place artist and the story behind their work.</p>
+                        </article>
+                        <article class="winner-card third-place" data-animate>
+                            <div class="winner-image image-placeholder">Add 3rd Place Photo</div>
+                            <h4>3rd Place</h4>
+                            <p>Celebrate the third-place winner by sharing their name, inspiration, and artwork details.</p>
+                        </article>
+                        <article class="winner-card honorable-mention" data-animate>
+                            <div class="winner-image image-placeholder">Add Honorable Mention Photo</div>
+                            <h4>Honorable Mention 1</h4>
+                            <p>Spotlight an additional artist by replacing this text with their recognition and artwork photo.</p>
+                        </article>
+                        <article class="winner-card honorable-mention" data-animate>
+                            <div class="winner-image image-placeholder">Add Honorable Mention Photo</div>
+                            <h4>Honorable Mention 2</h4>
+                            <p>Use this card to feature another standout submission from the competition.</p>
+                        </article>
+                        <article class="winner-card honorable-mention" data-animate>
+                            <div class="winner-image image-placeholder">Add Honorable Mention Photo</div>
+                            <h4>Honorable Mention 3</h4>
+                            <p>Share the story of this honoree by adding their photo, name, and the highlights of their artwork.</p>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="journey-section journey-section--alt" id="high-school">
+            <div class="container">
+                <div class="journey-header" data-animate>
+                    <h2>Government Senior Secondary School, Nathupur &mdash; High School</h2>
+                    <p>The high school program builds on early confidence to help students develop portfolios, leadership skills, and future-ready opportunities.</p>
+                </div>
+                <div class="journey-grid" data-animate-group>
+                    <article class="journey-card" data-animate>
+                        <h3>Program Snapshot</h3>
+                        <p>High school artists dive into advanced techniques while connecting their work to academic and career goals.</p>
+                        <ul>
+                            <li>Launch year: 2025 with 90 student artists across grades 9&ndash;12.</li>
+                            <li>Masterclasses with visiting artists and university mentors.</li>
+                            <li>Portfolio review days that prepare students for scholarships and exhibitions.</li>
+                        </ul>
+                    </article>
+                    <article class="journey-card" data-animate>
+                        <h3>Student Highlights</h3>
+                        <p>Upperclassmen co-create lesson plans and mentor younger peers, reinforcing collaborative leadership.</p>
+                        <ul>
+                            <li>Essay workshops linking artwork to advocacy and personal narrative.</li>
+                            <li>Cross-grade studio partnerships that pair high school mentors with middle school artists.</li>
+                            <li>Career panels exploring creative industries, design, and social impact.</li>
+                        </ul>
+                    </article>
+                    <article class="journey-card" data-animate>
+                        <h3>What's Next</h3>
+                        <p>We are preparing high school artists for opportunities beyond graduation.</p>
+                        <ul>
+                            <li>Establish internships with local galleries and cultural organizations.</li>
+                            <li>Develop digital showcases that amplify student work to global audiences.</li>
+                            <li>Create alumni networks that continue mentorship after students graduate.</li>
+                        </ul>
+                    </article>
+                </div>
+                <div class="journey-subsection journey-subsection--team" data-animate>
+                    <h3>Competition Team</h3>
+                    <p class="journey-subsection-lead">Get to know the coordinator and judges supporting our high school artists.</p>
+                    <div class="team-grid" data-animate-group>
+                        <article class="team-card coordinator" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Poonam Yadav">
+                            </div>
+                            <h4>Poonam Yadav</h4>
+                            <p class="team-role">Event Coordinator &middot; High School Division</p>
+                            <p>Poonam Yadav supports the high school division by coordinating logistics, mentors, and celebrations across campus. Replace this text with Poonam's accomplishments and stories from their work with older students.</p>
+                        </article>
+                        <article class="team-card judge" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Vandana Kothari">
+                            </div>
+                            <h4>Vandana Kothari</h4>
+                            <p class="team-role">Judge &middot; High School Panel</p>
+                            <p>Vandana Kothari mentors high school artists through portfolio reviews and vision-setting conversations. Replace this placeholder with Vandana's accolades and the guidance she offers the panel.</p>
+                        </article>
+                        <article class="team-card judge" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Deepak">
+                            </div>
+                            <h4>Deepak</h4>
+                            <p class="team-role">Judge &middot; High School Panel</p>
+                            <p>Deepak offers nuanced critiques that link high school artists' techniques with their long-term goals. Replace this copy with Deepak's creative journey and the expertise he brings to deliberations.</p>
+                        </article>
+                        <article class="team-card judge" data-animate>
+                            <div class="team-photo">
+                                <img src="images/logo.svg" alt="Placeholder portrait for Shweta">
+                            </div>
+                            <h4>Shweta</h4>
+                            <p class="team-role">Judge &middot; High School Panel</p>
+                            <p>Shweta celebrates each high school submission by amplifying student voice and collaborative spirit. Update this placeholder with Shweta's credentials and the support they share with finalists.</p>
+                        </article>
+                    </div>
+                </div>
+                <div class="journey-subsection journey-subsection--winners" data-animate>
+                    <h3>Winner Gallery</h3>
+                    <p class="journey-subsection-lead">Showcase the high school winners and honorable mentions once selections are made.</p>
+                    <div class="winner-grid" data-animate-group>
+                        <article class="winner-card first-place" data-animate>
+                            <div class="winner-image image-placeholder">Add 1st Place Photo</div>
+                            <h4>1st Place</h4>
+                            <p>Introduce the high school champion with their name, piece title, and a short description of their artistic vision.</p>
+                        </article>
+                        <article class="winner-card second-place" data-animate>
+                            <div class="winner-image image-placeholder">Add 2nd Place Photo</div>
+                            <h4>2nd Place</h4>
+                            <p>Replace this text with the second-place artist's accomplishments and insight into their creative process.</p>
+                        </article>
+                        <article class="winner-card third-place" data-animate>
+                            <div class="winner-image image-placeholder">Add 3rd Place Photo</div>
+                            <h4>3rd Place</h4>
+                            <p>Highlight the third-place finalist by adding their photo, name, and a sentence about their artwork.</p>
+                        </article>
+                        <article class="winner-card honorable-mention" data-animate>
+                            <div class="winner-image image-placeholder">Add Honorable Mention Photo</div>
+                            <h4>Honorable Mention 1</h4>
+                            <p>Provide the first honorable mention's information here once selections are finalized.</p>
+                        </article>
+                        <article class="winner-card honorable-mention" data-animate>
+                            <div class="winner-image image-placeholder">Add Honorable Mention Photo</div>
+                            <h4>Honorable Mention 2</h4>
+                            <p>Celebrate another honoree by adding their details and artwork image in this space.</p>
+                        </article>
+                        <article class="winner-card honorable-mention" data-animate>
+                            <div class="winner-image image-placeholder">Add Honorable Mention Photo</div>
+                            <h4>Honorable Mention 3</h4>
+                            <p>Use this placeholder to feature the final honorable mention and what makes their piece memorable.</p>
+                        </article>
+                    </div>
+                </div>
+                <div class="journey-callout" data-animate>
+                    <p>Help us continue this journey by supporting classroom resources and celebrating student achievements.</p>
+                    <div class="journey-actions">
+                        <a href="support.html" class="cta-button">Support Us</a>
+                        <a href="competition.html" class="secondary-button">Explore the Competition</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content" data-animate-group>
+                <div class="footer-logo" data-animate>
+                    <img src="images/logo.svg" alt="Artists of Tomorrow Logo">
+                    <span>Artists of Tomorrow</span>
+                </div>
+                <div class="footer-links" data-animate>
+                    <h4>Quick Links</h4>
+                    <ul class="quick-links-list" data-animate-group>
+                        <li><a href="index.html" data-animate>Home</a></li>
+                        <li><a href="about.html" data-animate>About</a></li>
+                        <li><a href="our-journey.html" data-animate>Our Journey</a></li>
+                        <li><a href="competition.html" data-animate>Competition</a></li>
+                        <li><a href="submission.html" data-animate>Submit Your Art</a></li>
+                        <li><a href="founders.html" data-animate>Founders</a></li>
+                        <li><a href="support.html" data-animate>Support Us</a></li>
+                        <li><a href="contact.html" data-animate>Contact</a></li>
+                        <li><a href="privacy.html" data-animate>Privacy Policy</a></li>
+                    </ul>
+                </div>
+                <div class="footer-contact" data-animate>
+                    <h4>Contact Us</h4>
+                    <div class="social-links">
+                    <a href="mailto:info.artistsoftomorrow@gmail.com" target="_blank" rel="noopener noreferrer" data-animate>
+                        <img src="images/logo.svg" alt="Artists of Tomorrow Logo" class="social-icon"> info.artistsoftomorrow@gmail.com
+                    </a>
+                    <a href="https://www.instagram.com/artists.0f.tomorrow/" target="_blank" rel="noopener noreferrer" data-animate>
+                        <img src="images/instagram-icon.png" alt="Instagram" class="social-icon"> Instagram
+                    </a>
+                    <a href="https://www.tiktok.com/@artists.of.tomorrow" target="_blank" rel="noopener noreferrer" data-animate>
+                        <img src="images/tiktok-icon.png" alt="TikTok" class="social-icon"> TikTok
+                    </a>
+                    <a href="https://www.gofundme.com/f/myzxfn-artists-of-tomorrow" target="_blank" rel="noopener noreferrer" data-animate>
+                        <img src="images/gofundme-icon.png" alt="GoFundMe" class="social-icon"> Support Us
+                    </a>
+                    </div>
+                </div>
+            </div>
+            <div class="copyright">
+                <p>&copy; 2025 Artists of Tomorrow. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/main.js"></script>
+    <script src="js/privacy-notice.js"></script>
+    <script src="js/clarity-helper.js"></script>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -45,8 +45,20 @@
             <ul>
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
+                <li class="has-submenu">
+                    <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
+                        Our Journey
+                        <span class="submenu-icon" aria-hidden="true"></span>
+                    </button>
+                    <ul class="submenu">
+                        <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                        <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                    </ul>
+                </li>
                 <li><a href="competition.html">Competition</a></li>
                 <li><a href="submission.html">Submit Your Art</a></li>
+                <li><a href="founders.html">Founders</a></li>
+                <li><a href="support.html">Support Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html" class="active">Privacy</a></li>
             </ul>
@@ -114,8 +126,11 @@
                     <ul class="quick-links-list" data-animate-group>
                         <li><a href="index.html" data-animate>Home</a></li>
                         <li><a href="about.html" data-animate>About</a></li>
+                        <li><a href="our-journey.html" data-animate>Our Journey</a></li>
                         <li><a href="competition.html" data-animate>Competition</a></li>
                         <li><a href="submission.html" data-animate>Submit Your Art</a></li>
+                        <li><a href="founders.html" data-animate>Founders</a></li>
+                        <li><a href="support.html" data-animate>Support Us</a></li>
                         <li><a href="contact.html" data-animate>Contact</a></li>
                         <li><a href="privacy.html" data-animate>Privacy Policy</a></li>
                     </ul>

--- a/submission.html
+++ b/submission.html
@@ -45,8 +45,20 @@
             <ul>
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
+                <li class="has-submenu">
+                    <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
+                        Our Journey
+                        <span class="submenu-icon" aria-hidden="true"></span>
+                    </button>
+                    <ul class="submenu">
+                        <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                        <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                    </ul>
+                </li>
                 <li><a href="competition.html">Competition</a></li>
                 <li><a href="submission.html" class="active">Submit Your Art</a></li>
+                <li><a href="founders.html">Founders</a></li>
+                <li><a href="support.html">Support Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="privacy.html">Privacy</a></li>
             </ul>
@@ -146,8 +158,11 @@
                     <ul class="quick-links-list" data-animate-group>
                         <li><a href="index.html" data-animate>Home</a></li>
                         <li><a href="about.html" data-animate>About</a></li>
+                        <li><a href="our-journey.html" data-animate>Our Journey</a></li>
                         <li><a href="competition.html" data-animate>Competition</a></li>
                         <li><a href="submission.html" data-animate>Submit Your Art</a></li>
+                        <li><a href="founders.html" data-animate>Founders</a></li>
+                        <li><a href="support.html" data-animate>Support Us</a></li>
                         <li><a href="contact.html" data-animate>Contact</a></li>
                         <li><a href="privacy.html" data-animate>Privacy Policy</a></li>
                     </ul>

--- a/support.html
+++ b/support.html
@@ -3,14 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact Us | Artists of Tomorrow</title>
-    <meta name="description" content="Get in touch with the Artists of Tomorrow team">
-    
+    <title>Support Us | Artists of Tomorrow</title>
+    <meta name="description" content="Support Artists of Tomorrow by funding art supplies, programming, and student recognition.">
+
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
-
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){
@@ -25,20 +22,9 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-    
+
       gtag('config', 'G-K8P4HJ9KY3');
     </script>
-    
-    <style>
-        /* Social media row hover effect */
-        .social-row:hover {
-            transform: translateX(5px);
-        }
-        
-        .social-row:hover a {
-            color: var(--primary-color);
-        }
-    </style>
 </head>
 <body>
     <header>
@@ -54,74 +40,77 @@
                 <span></span>
                 <span></span>
             </div>
-        <nav id="mainNav" class="collapsed">
-            <ul>
-                <li><a href="index.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li class="has-submenu">
-                    <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
-                        Our Journey
-                        <span class="submenu-icon" aria-hidden="true"></span>
-                    </button>
-                    <ul class="submenu">
-                        <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
-                        <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
-                    </ul>
-                </li>
-                <li><a href="competition.html">Competition</a></li>
-                <li><a href="submission.html">Submit Your Art</a></li>
-                <li><a href="founders.html">Founders</a></li>
-                <li><a href="support.html">Support Us</a></li>
-                <li><a href="contact.html" class="active">Contact</a></li>
-                <li><a href="privacy.html">Privacy</a></li>
-            </ul>
-        </nav>
+            <nav id="mainNav" class="collapsed">
+                <ul>
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="about.html">About</a></li>
+                    <li class="has-submenu">
+                        <button class="submenu-toggle" type="button" aria-expanded="false" aria-haspopup="true">
+                            Our Journey
+                            <span class="submenu-icon" aria-hidden="true"></span>
+                        </button>
+                        <ul class="submenu">
+                            <li><a href="our-journey.html#middle-school">Government Senior Secondary School, Nathupur &mdash; Middle School</a></li>
+                            <li><a href="our-journey.html#high-school">Government Senior Secondary School, Nathupur &mdash; High School</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="competition.html">Competition</a></li>
+                    <li><a href="submission.html">Submit Your Art</a></li>
+                    <li><a href="founders.html">Founders</a></li>
+                    <li><a href="support.html" class="active">Support Us</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                    <li><a href="privacy.html">Privacy</a></li>
+                </ul>
+            </nav>
         </div>
-</header>
+    </header>
 
     <main class="page-content">
         <section class="page-header">
             <div class="container" data-animate>
-                <h1>Contact Us</h1>
+                <h1>Support Artists of Tomorrow</h1>
             </div>
         </section>
 
-        <section class="contact-info" id="contact">
-            <div class="container" data-animate>
-                <div class="contact-container" data-animate>
-                    <div class="contact-details">
-                        <h2>Get In Touch</h2>
-                        <p>Have questions about the competition? Interested in supporting our mission? We'd love to hear from you!</p>
-
-                        <div class="contact-methods" data-animate-group>
-                            <div class="contact-method" data-animate>
-                                <h3>Email</h3>
-                                <p class="email-address">
-                                    <a href="mailto:info.artistsoftomorrow@gmail.com">info.artistsoftomorrow@gmail.com</a>
-                                </p>
-                            </div>
-                            <div class="contact-method" data-animate>
-                                <h3>Social Media</h3>
-                                <div class="social-row" data-animate>
-                                    <img src="images/instagram-icon.png" alt="Instagram">
-                                    <a href="https://www.instagram.com/artists.0f.tomorrow/" target="_blank" rel="noopener noreferrer">@artists.0f.tomorrow</a>
-                                </div>
-                                <div class="social-row" data-animate>
-                                    <img src="images/tiktok-icon.png" alt="TikTok">
-                                    <a href="https://www.tiktok.com/@artists.of.tomorrow" target="_blank" rel="noopener noreferrer">@artists.of.tomorrow</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+        <section class="support-page">
+            <div class="container support-content" data-animate-group>
+                <div class="support-text" data-animate>
+                    <h2>Fuel Creativity with Your Support</h2>
+                    <p>Your contribution ensures that every student artist receives the supplies, encouragement, and recognition they deserve. Together we can continue building spaces where young people feel empowered to share their stories through art and writing.</p>
+                    <ul class="support-list">
+                        <li>Provide sketchbooks, pencils, and writing materials for every student artist.</li>
+                        <li>Fund local showcases and award programs that celebrate student voice.</li>
+                        <li>Support transportation, translation, and mentoring resources for participating schools.</li>
+                    </ul>
+                </div>
+                <div class="gofundme-container" data-animate>
+                    <iframe src="https://www.gofundme.com/f/myzxfn-artists-of-tomorrow/widget/large"
+                            frameborder="0"
+                            scrolling="no"
+                            allowtransparency="true">
+                    </iframe>
                 </div>
             </div>
         </section>
 
-        <section class="support-cta">
-            <div class="container" data-animate>
-                <h2>Support Our Mission</h2>
-                <p>Artists of Tomorrow relies on the generous support of donors and volunteers to make our competition possible and provide art supplies to participating students.</p>
-                <a href="support.html" class="cta-button">Visit Support Us</a>
+        <section class="support-actions">
+            <div class="container">
+                <h2 data-animate>Other Ways to Help</h2>
+                <p data-animate>Every action you take keeps the competition vibrant and accessible. Explore the ideas below and let us know how you would like to get involved.</p>
+                <div class="support-actions-grid" data-animate-group>
+                    <article class="support-card" data-animate>
+                        <h3>Volunteer with Us</h3>
+                        <p>Share your time by mentoring students, supporting workshops, or assisting during judging days. We welcome creatives, educators, and community leaders alike.</p>
+                    </article>
+                    <article class="support-card" data-animate>
+                        <h3>Share the Story</h3>
+                        <p>Introduce Artists of Tomorrow to friends, family, and fellow educators by sharing our mission and GoFundMe campaign. Every mention helps us reach more classrooms.</p>
+                    </article>
+                    <article class="support-card" data-animate>
+                        <h3>Partner with Your School</h3>
+                        <p>Connect us with educators and administrators who are passionate about arts education. Together we can bring the competition to new campuses and communities.</p>
+                    </article>
+                </div>
             </div>
         </section>
     </main>
@@ -170,6 +159,7 @@
             </div>
         </div>
     </footer>
+
     <script src="js/main.js"></script>
     <script src="js/privacy-notice.js"></script>
     <script src="js/clarity-helper.js"></script>


### PR DESCRIPTION
## Summary
- surface the middle and high school competition teams and winner galleries directly on the Our Journey tabs
- smooth anchor scrolling and style the new journey subsections while removing the School Spotlights link-out from the competition overview
- auto-expand the Our Journey submenu for the active page so mobile navigation shows the school names reliably
- harden the submission registration helper so it skips missing fields instead of throwing console errors

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68cf3c3192a48330b0cbf3e506b6281e