### PR TITLE
Brighten hero title gradient

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -711,7 +711,7 @@ nav ul li .submenu a.active {
     font-size: clamp(2.5rem, 6vw, 4rem);
     line-height: 1.1;
     margin-bottom: 20px;
-    background: linear-gradient(135deg, #E59D83, #C4B5ED);
+    background: linear-gradient(135deg, #FFBEA6, #D8CBFF);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;


### PR DESCRIPTION
## Summary
- increase the brightness of the hero headline gradient while keeping the same orientation as the logo treatment

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d0a19edf988330a4c973a7d8eac12b