### PR TITLE
Adjust mobile menu toggle styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -435,13 +435,14 @@ header .container {
 .nav-toggle {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    width: 30px;
-    height: 24px;
+    justify-content: center;
+    gap: 6px;
+    width: 34px;
+    height: 28px;
     background: transparent;
     border: none;
     cursor: pointer;
-    padding: 10px 0;
+    padding: 0;
     z-index: 1001;
     position: relative;
 }
@@ -449,35 +450,29 @@ header .container {
 .nav-toggle span {
     display: block;
     width: 100%;
-    height: 2.5px;
+    height: 3px;
     background-color: var(--dark-color);
-    border-radius: 3px;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    border-radius: 999px;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     transform-origin: center;
-    position: relative;
-}
-
-.nav-toggle span:nth-child(1) {
-    transform: translateY(0) rotate(0);
 }
 
 .nav-toggle span:nth-child(2) {
     opacity: 1;
-    transform: scaleX(1);
 }
 
 .nav-toggle.active span:nth-child(1) {
-    transform: translateY(10px) rotate(45deg);
+    transform: translateY(9px) rotate(45deg);
     background-color: var(--primary-color);
 }
 
 .nav-toggle.active span:nth-child(2) {
     opacity: 0;
-    transform: scaleX(0);
 }
 
 .nav-toggle.active span:nth-child(3) {
-    transform: translateY(-10px) rotate(-45deg);
+    transform: translateY(-9px) rotate(-45deg);
     background-color: var(--primary-color);
 }
 
@@ -705,25 +700,46 @@ nav ul li .submenu a.active {
 
 .hero h1 {
     animation: fadeInUp 1s ease-out 0.2s both;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.022em;
     font-weight: 700; /* keep real 700 weight */
     font-family: var(--font-heading);
-    font-size: clamp(2.5rem, 6vw, 4rem);
-    line-height: 1.1;
-    margin-bottom: 20px;
-    background: linear-gradient(135deg, #FF8F6B 0%, #FFB4E6 55%, #CAB6FF 100%);
-    background: linear-gradient(135deg, #FFBEA6, #D8CBFF);
+    font-size: clamp(2.7rem, 6.5vw, 4.4rem);
+    line-height: 1.05;
+    margin-bottom: 24px;
+    display: inline-block;
+    position: relative;
+    padding: 0.25em 0.55em;
+    background: linear-gradient(120deg,
+            rgba(255, 236, 222, 0.95) 0%,
+            rgba(229, 157, 131, 0.98) 28%,
+            rgba(219, 193, 225, 0.95) 60%,
+            rgba(122, 184, 204, 0.96) 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
-    -webkit-text-stroke: 0;
+    -webkit-text-stroke: 1px rgba(255, 255, 255, 0.4);
     text-shadow:
-        0 10px 30px rgba(194, 110, 75, 0.38),
-        0 6px 22px rgba(138, 116, 208, 0.35),
-        0 3px 8px rgba(0, 0, 0, 0.18);
+        0 20px 40px rgba(194, 110, 75, 0.35),
+        0 16px 36px rgba(122, 184, 204, 0.32),
+        0 0 28px rgba(252, 240, 160, 0.85),
+        0 2px 8px rgba(0, 0, 0, 0.28);
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+.hero h1::before {
+    content: '';
+    position: absolute;
+    inset: 18% -14% 20%;
+    border-radius: 50px;
+    background: radial-gradient(circle at 20% 25%, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0) 60%),
+                radial-gradient(circle at 80% 40%, rgba(252, 240, 160, 0.85), rgba(252, 240, 160, 0) 68%),
+                linear-gradient(135deg, rgba(219, 193, 225, 0.55), rgba(122, 184, 204, 0.45));
+    filter: blur(18px);
+    opacity: 0.85;
+    z-index: -1;
+    mix-blend-mode: screen;
 }
 
 .hero h2 {


### PR DESCRIPTION
## Summary
- restyle the mobile navigation toggle to use evenly spaced horizontal bars
- adjust the active animation to keep the bars aligned when transitioning to the close icon
- intensify the hero title styling so "Artists of Tomorrow" pops with brighter gradients and glow effects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d4447674188330965c2cf900f46874