### PR TITLE
Update competition team bios and photos

### DIFF
--- a/our-journey.html
+++ b/our-journey.html
@@ -124,7 +124,7 @@
                             </div>
                             <h4>Poonam Yadav</h4>
                             <p class="team-role">Competition Organizer &middot; Middle School Division</p>
-                            <p>Poonam Yadav is a Gurugram-based artist and art teacher who has spent 15 years guiding students to merge emotion with vibrant color. Deeply influenced by folk and contemporary traditions, she curates nurturing spaces where middle school artists can translate feeling into confident artworks.</p>
+                            <p>Poonam Yadav is a Gurugram-based artist and art teacher who has practiced for 15 years. She works to merge emotion with vibrant colours on her own canvases and in her students' work, guided by the influence of folk and contemporary art.</p>
                         </article>
                         <article class="team-card judge" data-animate>
                             <div class="team-photo">
@@ -132,7 +132,7 @@
                             </div>
                             <h4>Vandana Kothari</h4>
                             <p class="team-role">Judge &middot; Middle School Panel</p>
-                            <p>Vandana Kothari is a Gurugram-based artist whose 20-year practice investigates identity, belonging, and visual language. Trained at Visva-Bharati and the Faculty of Fine Arts, Jaipur, she brings award-winning scholarship and professorships across premier Indian institutes to help young artists question, experiment, and articulate their own symbols.</p>
+                            <p>Vandana Kothari (b. 1978) is an Indian artist based in Gurgaon. Holding a Master's in History of Art from Visva-Bharati, Santiniketan, and a Bachelor's in Painting from the University of Rajasthan, she explores questions of identity, belonging, and visual language through abstraction and symbolic form.</p>
                         </article>
                         <article class="team-card judge" data-animate>
                             <div class="team-photo">
@@ -140,7 +140,7 @@
                             </div>
                             <h4>Deepak</h4>
                             <p class="team-role">Judge &middot; Middle School Panel</p>
-                            <p>Deepak is an enthusiastic TGT art teacher at GSSS Nathupur in Gurugram who champions Haryanvi culture and heritage. His critiques encourage middle school students to preserve local art forms while developing fresh interpretations that reflect their daily lives.</p>
+                            <p>Deepak is an enthusiastic and passionate TGT art teacher from GSSS Nathupur in Gurugram, Haryana. He believes in art and culture and aims to preserve the essence of Haryanvi culture and art forms with the young generation.</p>
                         </article>
                         <article class="team-card judge" data-animate>
                             <div class="team-photo">
@@ -148,7 +148,7 @@
                             </div>
                             <h4>Shweta</h4>
                             <p class="team-role">Judge &middot; Middle School Panel</p>
-                            <p>Shweta is a Gurugram-based fine art lecturer and lifelong art lover who delights in nurturing creativity. Actively involved in collaborative projects, she celebrates every submission as a chance to uplift young artists and the talent they reveal.</p>
+                            <p>Shweta is a fine art lecturer in Gurugram. An art lover and educator, she nurtures creativity among students, stays actively involved in creative projects, and feels happy witnessing the talent of young artists.</p>
                         </article>
                     </div>
                 </div>
@@ -236,7 +236,7 @@
                             </div>
                             <h4>Poonam Yadav</h4>
                             <p class="team-role">Competition Organizer &middot; High School Division</p>
-                            <p>A practicing artist for over 15 years, Poonam Yadav guides high schoolers to fuse emotion with sophisticated technique. Her folk and contemporary influences inform timelines, resource kits, and showcases that honor each student's expressive voice.</p>
+                            <p>Poonam Yadav is a Gurugram-based artist and art teacher who has practiced for 15 years. She works to merge emotion with vibrant colours on her own canvases and in her students' work, guided by the influence of folk and contemporary art.</p>
                         </article>
                         <article class="team-card judge" data-animate>
                             <div class="team-photo">
@@ -244,7 +244,7 @@
                             </div>
                             <h4>Vandana Kothari</h4>
                             <p class="team-role">Judge &middot; High School Panel</p>
-                            <p>Vandana's award-winning exhibitions at Nature Morte and recognition from Glenfiddich and WADE India underscore a practice steeped in inquiry. As Professor of Art at SPA New Delhi and former visiting faculty across IIT Kanpur, IIT Roorkee, MSU Baroda, and the University of Rajasthan, she helps high school artists frame ambitious, research-driven portfolios.</p>
+                            <p>Vandana Kothari (b. 1978) is an Indian artist based in Gurgaon. She holds a Master's in History of Art from Visva-Bharati, Santiniketan, and a Bachelor's in Painting from the University of Rajasthan. Her practice examines identity, belonging, and visual language, supported by exhibitions at Nature Morte, recognition as a Glenfiddich Emerging Artist finalist (2017), the WADE India Artists Award (2016), and her role as Professor of Art at the School of Planning and Architecture, New Delhi.</p>
                         </article>
                         <article class="team-card judge" data-animate>
                             <div class="team-photo">
@@ -252,7 +252,7 @@
                             </div>
                             <h4>Deepak</h4>
                             <p class="team-role">Judge &middot; High School Panel</p>
-                            <p>Deepak brings passionate advocacy for art and culture into every critique, encouraging teenagers to safeguard Haryanvi traditions while stretching toward new ideas. His mentorship helps high school students connect studio practice with their futures.</p>
+                            <p>Deepak is an enthusiastic and passionate TGT art teacher from GSSS Nathupur in Gurugram, Haryana. He believes in art and culture and aims to preserve the essence of Haryanvi culture and art forms with the young generation.</p>
                         </article>
                         <article class="team-card judge" data-animate>
                             <div class="team-photo">
@@ -260,7 +260,7 @@
                             </div>
                             <h4>Shweta</h4>
                             <p class="team-role">Judge &middot; High School Panel</p>
-                            <p>Shweta's studio critiques celebrate the voice behind every artwork while helping teens refine technique for college-ready portfolios. She delights in collaborative learning and feels happiest when she can champion the talent of emerging young artists.</p>
+                            <p>Shweta is a fine art lecturer in Gurugram. An art lover and educator, she nurtures creativity among students, stays actively involved in creative projects, and feels happy witnessing the talent of young artists.</p>
                         </article>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- replace placeholder team portraits with the new Deepak, Shweta, Poonam, and Vandana photos
- refresh middle and high school competition bios to reflect the educators' current introductions and accomplishments

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_b_68d44b50c3208330af9f67705460f44b