### PR TITLE
Increase competition team profile photo size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2308,8 +2308,8 @@ footer::before {
 }
 
 .team-photo {
-    width: 96px;
-    height: 96px;
+    width: 140px;
+    height: 140px;
     border-radius: 50%;
     background: var(--peach-light);
     display: flex;
@@ -2321,8 +2321,9 @@ footer::before {
 }
 
 .team-photo img {
-    width: 64px;
-    height: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .team-card h3,


### PR DESCRIPTION
## Summary
- enlarge competition team profile photo container for a stronger visual presence
- allow profile images to fully cover the circular frame using object-fit

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d451bc136c83309fe5f5e10f2243cf