### PR TITLE
Color hero words with bright tones

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -732,51 +732,51 @@ nav ul li .submenu a.active {
     font-size: clamp(2.7rem, 6.5vw, 4.4rem);
     line-height: 1.05;
     margin-bottom: 24px;
-    display: inline-block;
+    display: inline-flex;
+    gap: 0.2em;
+    flex-wrap: wrap;
+    justify-content: center;
     position: relative;
-    padding: 0.25em 0.55em;
-    color: transparent;
-    background: linear-gradient(120deg,
-            color-mix(in srgb, var(--purple-bright) 68%, var(--white) 32%) 0%,
-            color-mix(in srgb, var(--pink-bright) 80%, var(--white) 20%) 52%,
-            color-mix(in srgb, var(--blue-bright) 78%, var(--white) 22%) 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    text-shadow:
-        0 18px 38px color-mix(in srgb, var(--purple-dark) 28%, transparent),
-        0 16px 34px color-mix(in srgb, var(--pink) 34%, transparent),
-        0 0 30px color-mix(in srgb, var(--blue) 36%, transparent),
-        0 3px 12px rgba(20, 24, 40, 0.26);
-    color: color-mix(in srgb, var(--gold) 88%, var(--white) 12%);
-    text-shadow:
-        0 18px 38px color-mix(in srgb, var(--salmon-bright) 38%, transparent),
-        0 16px 34px color-mix(in srgb, var(--blue-bright) 32%, transparent),
-        0 0 30px color-mix(in srgb, var(--yellow-bright) 70%, transparent),
-        0 3px 12px rgba(0, 0, 0, 0.26);
-    color: color-mix(in srgb, var(--gold) 90%, var(--white) 10%);
-    text-shadow:
-        0 18px 38px color-mix(in srgb, var(--salmon-bright) 42%, transparent),
-        0 16px 34px color-mix(in srgb, #fdba54 36%, transparent),
-        0 0 30px color-mix(in srgb, var(--yellow-bright) 74%, transparent),
-        0 3px 12px rgba(0, 0, 0, 0.26);
-    background: linear-gradient(118deg,
-            color-mix(in srgb, var(--salmon-bright) 40%, var(--white)) 0%,
-            color-mix(in srgb, var(--salmon-bright) 70%, var(--white) 30%) 22%,
-            color-mix(in srgb, var(--pink-bright) 68%, var(--white) 32%) 48%,
-            color-mix(in srgb, var(--purple-bright) 70%, var(--white) 30%) 70%,
-            color-mix(in srgb, var(--blue-bright) 72%, var(--white) 28%) 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    -webkit-text-stroke: 1.25px rgba(255, 255, 255, 0.55);
-    text-shadow:
-        0 18px 38px rgba(229, 157, 131, 0.32),
-        0 16px 34px rgba(122, 184, 204, 0.28),
-        0 0 26px rgba(255, 232, 163, 0.6),
-        0 3px 10px rgba(0, 0, 0, 0.24);
+    padding: 0.28em 0.6em;
+    color: #ff3dd6;
+    background: none;
+    -webkit-text-fill-color: currentColor;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+.hero h1 .hero-title-word {
+    display: inline-block;
+    position: relative;
+    padding: 0 0.05em;
+    color: inherit;
+    -webkit-text-fill-color: currentColor;
+    text-shadow: none;
+}
+
+.hero h1 .hero-title-word--artists {
+    color: #ff3dd6;
+    text-shadow:
+        0 16px 38px rgba(255, 61, 214, 0.48),
+        0 6px 18px rgba(255, 61, 214, 0.55),
+        0 0 28px rgba(255, 156, 243, 0.35);
+}
+
+.hero h1 .hero-title-word--of {
+    color: #ba62ff;
+    text-shadow:
+        0 16px 34px rgba(186, 98, 255, 0.5),
+        0 6px 18px rgba(117, 54, 199, 0.38),
+        0 0 26px rgba(210, 162, 255, 0.32);
+}
+
+.hero h1 .hero-title-word--tomorrow {
+    color: #3ec0ff;
+    text-shadow:
+        0 16px 36px rgba(62, 192, 255, 0.48),
+        0 6px 18px rgba(21, 123, 201, 0.42),
+        0 0 28px rgba(154, 220, 255, 0.34);
 }
 
 .hero h1::before {
@@ -785,25 +785,14 @@ nav ul li .submenu a.active {
     inset: 18% -14% 20%;
     border-radius: 50px;
     background:
-        radial-gradient(circle at 18% 24%, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0) 62%),
-        radial-gradient(circle at 78% 38%, color-mix(in srgb, var(--pink-bright) 78%, transparent), rgba(234, 208, 252, 0) 70%),
+        radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0) 62%),
+        radial-gradient(circle at 75% 38%, rgba(255, 92, 217, 0.4), rgba(255, 153, 255, 0) 70%),
+        radial-gradient(circle at 45% 70%, rgba(62, 190, 255, 0.38), rgba(130, 215, 255, 0) 65%),
         linear-gradient(135deg,
-            color-mix(in srgb, var(--purple-bright) 64%, transparent),
-            color-mix(in srgb, var(--blue-bright) 58%, transparent));
-        radial-gradient(circle at 78% 38%, color-mix(in srgb, var(--yellow-bright) 78%, transparent), rgba(255, 224, 102, 0) 70%),
-        linear-gradient(135deg,
-            color-mix(in srgb, var(--salmon-bright) 64%, transparent),
-            color-mix(in srgb, #ffad51 58%, transparent));
-    background: radial-gradient(circle at 18% 24%, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0) 62%),
-                radial-gradient(circle at 78% 38%, rgba(255, 224, 102, 0.92), rgba(255, 224, 102, 0) 70%),
-                linear-gradient(135deg, rgba(244, 169, 248, 0.62), rgba(99, 197, 245, 0.56));
-    background: radial-gradient(circle at 18% 24%, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0) 62%),
-                radial-gradient(circle at 78% 38%, color-mix(in srgb, var(--yellow-bright) 72%, transparent), rgba(255, 224, 102, 0) 70%),
-                linear-gradient(135deg,
-                    color-mix(in srgb, var(--pink-bright) 52%, transparent),
-                    color-mix(in srgb, var(--blue-bright) 48%, transparent));
+            rgba(180, 69, 255, 0.36),
+            rgba(62, 190, 255, 0.32));
     filter: blur(16px);
-    opacity: 0.9;
+    opacity: 0.92;
     z-index: -1;
     mix-blend-mode: screen;
 }

--- a/index.html
+++ b/index.html
@@ -69,7 +69,11 @@
     <main class="page-content">
         <section class="hero">
             <div class="container hero-content" data-animate>
-                <h1>Artists of Tomorrow</h1>
+                <h1>
+                    <span class="hero-title-word hero-title-word--artists">Artists</span>
+                    <span class="hero-title-word hero-title-word--of">of</span>
+                    <span class="hero-title-word hero-title-word--tomorrow">Tomorrow</span>
+                </h1>
                 <h2>Empowering Children Through Art & Self-Expression</h2>
                 <a href="competition.html" class="cta-button">Learn About the Competition</a>
             </div>


### PR DESCRIPTION
## Summary
- wrap each hero title word in dedicated spans so the lettering itself shows saturated pink, purple, and blue fills
- adjust the hero heading styling to center the new word treatments while keeping the surrounding glow effect intact

## Testing
- not run (static styling change)


------
https://chatgpt.com/codex/tasks/task_b_68d4612288388330bb8b8f60c1003a11