### PR TITLE
Align hero title colors with logo palette

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -738,7 +738,7 @@ nav ul li .submenu a.active {
     justify-content: center;
     position: relative;
     padding: 0.28em 0.6em;
-    color: #ff3dd6;
+    color: var(--salmon);
     background: none;
     -webkit-text-fill-color: currentColor;
     text-rendering: optimizeLegibility;
@@ -756,27 +756,27 @@ nav ul li .submenu a.active {
 }
 
 .hero h1 .hero-title-word--artists {
-    color: #ff3dd6;
+    color: var(--salmon);
     text-shadow:
-        0 16px 38px rgba(255, 61, 214, 0.48),
-        0 6px 18px rgba(255, 61, 214, 0.55),
-        0 0 28px rgba(255, 156, 243, 0.35);
+        0 12px 28px color-mix(in srgb, var(--salmon) 40%, transparent),
+        0 6px 18px color-mix(in srgb, var(--salmon-bright) 48%, transparent),
+        0 0 22px color-mix(in srgb, var(--salmon) 32%, var(--white) 68%);
 }
 
 .hero h1 .hero-title-word--of {
-    color: #ba62ff;
+    color: var(--purple);
     text-shadow:
-        0 16px 34px rgba(186, 98, 255, 0.5),
-        0 6px 18px rgba(117, 54, 199, 0.38),
-        0 0 26px rgba(210, 162, 255, 0.32);
+        0 12px 28px color-mix(in srgb, var(--purple) 42%, transparent),
+        0 6px 18px color-mix(in srgb, var(--purple-bright) 46%, transparent),
+        0 0 22px color-mix(in srgb, var(--purple) 30%, var(--white) 70%);
 }
 
 .hero h1 .hero-title-word--tomorrow {
-    color: #3ec0ff;
+    color: var(--blue);
     text-shadow:
-        0 16px 36px rgba(62, 192, 255, 0.48),
-        0 6px 18px rgba(21, 123, 201, 0.42),
-        0 0 28px rgba(154, 220, 255, 0.34);
+        0 12px 28px color-mix(in srgb, var(--blue) 44%, transparent),
+        0 6px 18px color-mix(in srgb, var(--blue-bright) 48%, transparent),
+        0 0 22px color-mix(in srgb, var(--blue) 32%, var(--white) 68%);
 }
 
 .hero h1::before {
@@ -785,12 +785,13 @@ nav ul li .submenu a.active {
     inset: 18% -14% 20%;
     border-radius: 50px;
     background:
-        radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0) 62%),
-        radial-gradient(circle at 75% 38%, rgba(255, 92, 217, 0.4), rgba(255, 153, 255, 0) 70%),
-        radial-gradient(circle at 45% 70%, rgba(62, 190, 255, 0.38), rgba(130, 215, 255, 0) 65%),
+        radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0) 62%),
+        radial-gradient(circle at 75% 38%, color-mix(in srgb, var(--salmon) 35%, transparent) 0%, transparent 70%),
+        radial-gradient(circle at 45% 70%, color-mix(in srgb, var(--blue) 32%, transparent) 0%, transparent 65%),
         linear-gradient(135deg,
-            rgba(180, 69, 255, 0.36),
-            rgba(62, 190, 255, 0.32));
+            color-mix(in srgb, var(--salmon) 42%, var(--white) 58%),
+            color-mix(in srgb, var(--purple) 46%, var(--white) 54%),
+            color-mix(in srgb, var(--blue) 40%, var(--white) 60%));
     filter: blur(16px);
     opacity: 0.92;
     z-index: -1;


### PR DESCRIPTION
## Summary
- update the hero heading colors to match the salmon, lavender, and blue used in the logo
- soften the associated glow and highlight effects to complement the revised palette

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d46b65ce748330b8ee8cb4d16ef3ac