### PR TITLE
Remove hero title glow background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -779,23 +779,9 @@ nav ul li .submenu a.active {
         0 0 22px color-mix(in srgb, var(--blue) 32%, var(--white) 68%);
 }
 
+/* Remove glow behind hero title for cleaner presentation */
 .hero h1::before {
-    content: '';
-    position: absolute;
-    inset: 18% -14% 20%;
-    border-radius: 50px;
-    background:
-        radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0) 62%),
-        radial-gradient(circle at 75% 38%, color-mix(in srgb, var(--salmon) 35%, transparent) 0%, transparent 70%),
-        radial-gradient(circle at 45% 70%, color-mix(in srgb, var(--blue) 32%, transparent) 0%, transparent 65%),
-        linear-gradient(135deg,
-            color-mix(in srgb, var(--salmon) 42%, var(--white) 58%),
-            color-mix(in srgb, var(--purple) 46%, var(--white) 54%),
-            color-mix(in srgb, var(--blue) 40%, var(--white) 60%));
-    filter: blur(16px);
-    opacity: 0.92;
-    z-index: -1;
-    mix-blend-mode: screen;
+    content: none;
 }
 
 .hero h2 {


### PR DESCRIPTION
## Summary
- remove the pseudo-element that created the white glow behind the hero title
- leave the hero heading with its original text color styling but without the blurred background highlight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4741f6c148330bec1a3821cc502e6