### PR TITLE
Add competition photo carousels to winner galleries

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2229,6 +2229,149 @@ footer::before {
     margin-top: 32px;
 }
 
+.photo-gallery {
+    margin-top: 48px;
+}
+
+.photo-gallery h4 {
+    font-family: var(--font-heading);
+    font-size: clamp(1.3rem, 1.1rem + 0.5vw, 1.6rem);
+    margin-bottom: 18px;
+    text-align: center;
+    color: var(--secondary-color);
+}
+
+.photo-carousel {
+    position: relative;
+    padding: 0 48px;
+}
+
+.carousel-track {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(220px, min(32vw, 320px));
+    gap: 18px;
+    overflow-x: auto;
+    padding: 12px 0 12px 12px;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+}
+
+.carousel-track:focus {
+    outline: 3px solid rgba(229, 157, 131, 0.45);
+    outline-offset: 4px;
+}
+
+.carousel-track::-webkit-scrollbar {
+    display: none;
+}
+
+.carousel-item {
+    scroll-snap-align: center;
+    border-radius: 16px;
+    overflow: hidden;
+    background: var(--white);
+    box-shadow: var(--box-shadow);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.carousel-item img {
+    width: 100%;
+    display: block;
+    height: 100%;
+    object-fit: cover;
+}
+
+.carousel-control {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: var(--primary-color);
+    color: var(--white);
+    border: none;
+    border-radius: 50%;
+    width: 42px;
+    height: 42px;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: var(--box-shadow);
+    transition: transform var(--transition-medium), background var(--transition-medium);
+}
+
+.carousel-control:hover,
+.carousel-control:focus-visible {
+    background: var(--secondary-color);
+    transform: translateY(-50%) scale(1.05);
+}
+
+.carousel-control:disabled {
+    opacity: 0.45;
+    cursor: default;
+    background: rgba(0, 0, 0, 0.2);
+    box-shadow: none;
+}
+
+.carousel-control:disabled:hover,
+.carousel-control:disabled:focus-visible {
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.carousel-control span {
+    font-size: 1.6rem;
+    line-height: 1;
+}
+
+.carousel-control--prev {
+    left: 0;
+}
+
+.carousel-control--next {
+    right: 0;
+}
+
+@media (max-width: 1024px) {
+    .photo-carousel {
+        padding: 0 36px;
+    }
+}
+
+@media (max-width: 768px) {
+    .photo-carousel {
+        padding: 0 24px;
+    }
+
+    .carousel-track {
+        grid-auto-columns: minmax(200px, 72%);
+        padding: 12px 0;
+    }
+
+    .carousel-control {
+        width: 36px;
+        height: 36px;
+    }
+}
+
+@media (max-width: 520px) {
+    .photo-gallery {
+        margin-top: 36px;
+    }
+
+    .photo-carousel {
+        padding: 0 16px;
+    }
+
+    .carousel-track {
+        grid-auto-columns: minmax(180px, 86%);
+        gap: 14px;
+    }
+}
+
 .journey-card {
     background: var(--white);
     border-radius: 16px;

--- a/js/main.js
+++ b/js/main.js
@@ -456,9 +456,74 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
     };
-    
+
     enhancePrizes();
-    
+
+    // Photo carousel controls
+    document.querySelectorAll('[data-carousel]').forEach(carousel => {
+        const track = carousel.querySelector('[data-carousel-track]');
+        if (!track) {
+            return;
+        }
+
+        const prevButton = carousel.querySelector('[data-carousel-prev]');
+        const nextButton = carousel.querySelector('[data-carousel-next]');
+        let scrollAnimationFrame = null;
+
+        const getScrollStep = () => track.clientWidth * 0.8;
+
+        const updateControls = () => {
+            const maxScroll = track.scrollWidth - track.clientWidth;
+            if (prevButton) {
+                prevButton.disabled = track.scrollLeft <= 1;
+            }
+            if (nextButton) {
+                nextButton.disabled = track.scrollLeft >= (maxScroll - 1);
+            }
+        };
+
+        const scheduleUpdate = () => {
+            if (scrollAnimationFrame) {
+                cancelAnimationFrame(scrollAnimationFrame);
+            }
+            scrollAnimationFrame = requestAnimationFrame(updateControls);
+        };
+
+        const scrollByAmount = direction => {
+            track.scrollBy({
+                left: direction * getScrollStep(),
+                behavior: reduceMotion ? 'auto' : 'smooth'
+            });
+        };
+
+        if (prevButton) {
+            prevButton.addEventListener('click', () => {
+                scrollByAmount(-1);
+            });
+        }
+
+        if (nextButton) {
+            nextButton.addEventListener('click', () => {
+                scrollByAmount(1);
+            });
+        }
+
+        track.addEventListener('scroll', scheduleUpdate, { passive: true });
+
+        track.addEventListener('keydown', event => {
+            if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                scrollByAmount(-1);
+            } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                scrollByAmount(1);
+            }
+        });
+
+        window.addEventListener('resize', scheduleUpdate);
+        updateControls();
+    });
+
     // Add particle effect to buttons
     const addButtonEffects = function() {
         const buttons = document.querySelectorAll('.cta-button, .secondary-button');

--- a/our-journey.html
+++ b/our-journey.html
@@ -154,14 +154,12 @@
                 </div>
                 <div class="journey-subsection journey-subsection--winners" data-animate>
                     <h3>Winner Gallery</h3>
-                    <p class="journey-subsection-lead">Replace these placeholders with photos and celebrations for your middle school winners.</p>
                     <div class="winner-grid" data-animate-group>
                         <article class="winner-card first-place" data-animate>
                             <div class="winner-image">
                                 <img src="images/1stPlaceMiddleSchool.jpg" alt="Artwork by the 1st place middle school winner">
                             </div>
                             <h4>1st Place</h4>
-                            <p>Share the winner's name, artwork title, and a short celebration of their piece here.</p>
                         </article>
                         <article class="winner-card second-place" data-animate>
                             <div class="winner-image">
@@ -198,6 +196,56 @@
                             <h4>Honorable Mention 3</h4>
                             <p>Share the story of this honoree by adding their photo, name, and the highlights of their artwork.</p>
                         </article>
+                    </div>
+                    <div class="photo-gallery" data-animate>
+                        <h4>Photo Gallery</h4>
+                        <div class="photo-carousel" data-carousel>
+                            <button class="carousel-control carousel-control--prev" type="button" aria-label="Scroll to previous middle school photos" data-carousel-prev>
+                                <span aria-hidden="true">&#10094;</span>
+                            </button>
+                            <div class="carousel-track" data-carousel-track tabindex="0" aria-label="Middle school competition photo gallery">
+                                <figure class="carousel-item"><img src="images/compnathupur/1stHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 1 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/1stHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 2 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/1stPlaceHighSchoolDisplay.jpeg" alt="Competition photo 3 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/1stPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 4 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 5 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 6 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndPlaceHighSchoolDisplay.jpeg" alt="Competition photo 7 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndPlaceMiddleSchoolDisplay.jpeg" alt="Competition photo 8 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 9 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 10 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdPlaceHighSchoolDisplay.jpeg" alt="Competition photo 11 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 12 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-19-27.jpg" alt="Competition photo 13 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-19-28.jpg" alt="Competition photo 14 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-19.jpg" alt="Competition photo 15 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20%202.jpg" alt="Competition photo 16 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20%203.jpg" alt="Competition photo 17 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20.jpg" alt="Competition photo 18 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-21%202.jpg" alt="Competition photo 19 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-21.jpg" alt="Competition photo 20 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22%202.jpg" alt="Competition photo 21 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22%203.jpg" alt="Competition photo 22 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22.jpg" alt="Competition photo 23 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23%202.jpg" alt="Competition photo 24 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23%203.jpg" alt="Competition photo 25 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23.jpg" alt="Competition photo 26 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-24.jpg" alt="Competition photo 27 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-25.jpg" alt="Competition photo 28 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26%202.jpg" alt="Competition photo 29 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26%203.jpg" alt="Competition photo 30 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26.jpg" alt="Competition photo 31 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27%202.jpg" alt="Competition photo 32 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27%203.jpg" alt="Competition photo 33 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27.jpg" alt="Competition photo 34 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-28.jpg" alt="Competition photo 35 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-57-22.jpg" alt="Competition photo 36 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-22.jpg" alt="Competition photo 37 from Nathupur event"></figure>
+                            </div>
+                            <button class="carousel-control carousel-control--next" type="button" aria-label="Scroll to next middle school photos" data-carousel-next>
+                                <span aria-hidden="true">&#10095;</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -322,6 +370,56 @@
                             <h4>Honorable Mention 3</h4>
                             <p>A vibrant colour palette and expressive marks made this piece stand out as a joyful celebration of motion.</p>
                         </article>
+                    </div>
+                    <div class="photo-gallery" data-animate>
+                        <h4>Photo Gallery</h4>
+                        <div class="photo-carousel" data-carousel>
+                            <button class="carousel-control carousel-control--prev" type="button" aria-label="Scroll to previous high school photos" data-carousel-prev>
+                                <span aria-hidden="true">&#10094;</span>
+                            </button>
+                            <div class="carousel-track" data-carousel-track tabindex="0" aria-label="High school competition photo gallery">
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-23%202.jpg" alt="Competition photo 1 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-23.jpg" alt="Competition photo 2 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-20%202.jpg" alt="Competition photo 3 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-20.jpg" alt="Competition photo 4 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21%202.jpg" alt="Competition photo 5 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21%203.jpg" alt="Competition photo 6 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21.jpg" alt="Competition photo 7 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-32%202.jpg" alt="Competition photo 8 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-32.jpg" alt="Competition photo 9 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33%202.jpg" alt="Competition photo 10 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33%203.jpg" alt="Competition photo 11 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33.jpg" alt="Competition photo 12 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-34%202.jpg" alt="Competition photo 13 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-34.jpg" alt="Competition photo 14 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35%202.jpg" alt="Competition photo 15 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35%203.jpg" alt="Competition photo 16 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35.jpg" alt="Competition photo 17 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36%202.jpg" alt="Competition photo 18 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36%203.jpg" alt="Competition photo 19 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36.jpg" alt="Competition photo 20 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37%202.jpg" alt="Competition photo 21 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37%203.jpg" alt="Competition photo 22 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37.jpg" alt="Competition photo 23 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-38%203.jpg" alt="Competition photo 24 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-39%202.jpg" alt="Competition photo 25 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-39.jpg" alt="Competition photo 26 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40%202.jpg" alt="Competition photo 27 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40%203.jpg" alt="Competition photo 28 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40.jpg" alt="Competition photo 29 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-10-12-31.jpg" alt="Competition photo 30 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-10-43-01.jpg" alt="Competition photo 31 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-13.jpg" alt="Competition photo 32 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-14%202.jpg" alt="Competition photo 33 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-14.jpg" alt="Competition photo 34 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-15.jpg" alt="Competition photo 35 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-12-34-54.jpg" alt="Competition photo 36 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-12-35-11.jpg" alt="Competition photo 37 from Nathupur high school event"></figure>
+                            </div>
+                            <button class="carousel-control carousel-control--next" type="button" aria-label="Scroll to next high school photos" data-carousel-next>
+                                <span aria-hidden="true">&#10095;</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
                 <div class="journey-callout" data-animate>


### PR DESCRIPTION
## Summary
- add dedicated photo galleries beneath the middle- and high-school winner sections featuring 37 competition photos each
- style new carousels for responsive horizontal scrolling with accessible controls
- enable carousel buttons and keyboard navigation with JavaScript, and remove outdated placeholder copy

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d48d3040248330ae484c65468c9c25