### PR TITLE
Revamp winner galleries and carousels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2229,6 +2229,226 @@ footer::before {
     margin-top: 32px;
 }
 
+.photo-gallery {
+    margin-top: 48px;
+}
+
+.photo-gallery h4 {
+    font-family: var(--font-heading);
+    font-size: clamp(1.3rem, 1.1rem + 0.5vw, 1.6rem);
+    margin-bottom: 18px;
+    text-align: center;
+    color: var(--secondary-color);
+}
+
+.photo-carousel {
+    position: relative;
+    padding: 0 64px;
+}
+
+.carousel-track {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(340px, min(40vw, 560px));
+    gap: 22px;
+    overflow-x: auto;
+    padding: 16px 0 16px 16px;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+    border-radius: 22px;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05), 0 18px 32px rgba(0, 0, 0, 0.08);
+}
+
+.carousel-track:focus {
+    outline: 3px solid rgba(229, 157, 131, 0.45);
+    outline-offset: 4px;
+}
+
+.carousel-track::-webkit-scrollbar {
+    display: none;
+}
+
+.carousel-item {
+    scroll-snap-align: center;
+    border-radius: 18px;
+    overflow: hidden;
+    background: var(--white);
+    box-shadow: var(--box-shadow-hover);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    aspect-ratio: 16 / 9;
+    position: relative;
+    cursor: zoom-in;
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
+}
+
+.carousel-item:focus-visible,
+.carousel-item:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--box-shadow-strong);
+    outline: none;
+}
+
+.carousel-item img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: cover;
+}
+
+.carousel-control {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: var(--primary-color);
+    color: var(--white);
+    border: none;
+    border-radius: 50%;
+    width: 42px;
+    height: 42px;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: var(--box-shadow);
+    transition: transform var(--transition-medium), background var(--transition-medium);
+}
+
+.carousel-control:hover,
+.carousel-control:focus-visible {
+    background: var(--secondary-color);
+    transform: translateY(-50%) scale(1.05);
+}
+
+.carousel-control:disabled {
+    opacity: 0.45;
+    cursor: default;
+    background: rgba(0, 0, 0, 0.2);
+    box-shadow: none;
+}
+
+.carousel-control:disabled:hover,
+.carousel-control:disabled:focus-visible {
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.carousel-control span {
+    font-size: 1.6rem;
+    line-height: 1;
+}
+
+.carousel-control--prev {
+    left: 0;
+}
+
+.carousel-control--next {
+    right: 0;
+}
+
+@media (max-width: 1024px) {
+    .photo-carousel {
+        padding: 0 48px;
+    }
+}
+
+@media (max-width: 768px) {
+    .photo-carousel {
+        padding: 0 24px;
+    }
+
+    .carousel-track {
+        grid-auto-columns: minmax(260px, 80%);
+        padding: 12px 0;
+        gap: 18px;
+    }
+
+    .carousel-control {
+        width: 36px;
+        height: 36px;
+    }
+}
+
+@media (max-width: 520px) {
+    .photo-gallery {
+        margin-top: 36px;
+    }
+
+    .photo-carousel {
+        padding: 0 16px;
+    }
+
+    .carousel-track {
+        grid-auto-columns: minmax(220px, 88%);
+        gap: 16px;
+    }
+}
+
+.lightbox {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 22, 35, 0.82);
+    backdrop-filter: blur(6px);
+    display: grid;
+    place-items: center;
+    padding: 32px;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition-medium), visibility var(--transition-medium);
+    z-index: 999;
+}
+
+.lightbox.is-active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.lightbox__figure {
+    max-width: min(1200px, 92vw);
+    width: 100%;
+    position: relative;
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 28px 60px rgba(0, 0, 0, 0.4);
+    background: var(--dark-color);
+}
+
+.lightbox__image {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: contain;
+    background: var(--dark-color);
+}
+
+.lightbox__close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(0, 0, 0, 0.6);
+    color: var(--white);
+    font-size: 1.6rem;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.lightbox__close:hover,
+.lightbox__close:focus-visible {
+    background: rgba(0, 0, 0, 0.8);
+    transform: scale(1.05);
+    outline: none;
+}
+
+body.lightbox-open {
+    overflow: hidden;
+}
+
 .journey-card {
     background: var(--white);
     border-radius: 16px;

--- a/our-journey.html
+++ b/our-journey.html
@@ -152,52 +152,95 @@
                         </article>
                     </div>
                 </div>
-                <div class="journey-subsection journey-subsection--winners" data-animate>
-                    <h3>Winner Gallery</h3>
-                    <p class="journey-subsection-lead">Replace these placeholders with photos and celebrations for your middle school winners.</p>
-                    <div class="winner-grid" data-animate-group>
-                        <article class="winner-card first-place" data-animate>
-                            <div class="winner-image">
-                                <img src="images/1stPlaceMiddleSchool.jpg" alt="Artwork by the 1st place middle school winner">
+                    <div class="journey-subsection journey-subsection--winners" data-animate>
+                        <h3>Winner Gallery</h3>
+                        <div class="winner-grid" data-animate-group>
+                            <article class="winner-card first-place" data-animate>
+                                <div class="winner-image">
+                                    <img src="images/1stPlaceMiddleSchool.jpg" alt="Artwork by the 1st place middle school winner">
+                                </div>
+                                <h4>1st Place</h4>
+                            </article>
+                            <article class="winner-card second-place" data-animate>
+                                <div class="winner-image">
+                                    <img src="images/2ndPlaceMiddleSchool.jpeg" alt="Artwork by the 2nd place middle school winner">
+                                </div>
+                                <h4>2nd Place</h4>
+                            </article>
+                            <article class="winner-card third-place" data-animate>
+                                <div class="winner-image">
+                                    <img src="images/3rdPlaceMiddleSchool.jpg" alt="Artwork by the 3rd place middle school winner">
+                                </div>
+                                <h4>3rd Place</h4>
+                            </article>
+                            <article class="winner-card honorable-mention" data-animate>
+                                <div class="winner-image">
+                                    <img src="images/1stHonorableMentionMiddleSchool.jpeg" alt="Artwork recognized with honorable mention in the middle school competition">
+                                </div>
+                                <h4>Honorable Mention 1</h4>
+                            </article>
+                            <article class="winner-card honorable-mention" data-animate>
+                                <div class="winner-image">
+                                    <img src="images/2ndHonorableMentionMiddleSchool.jpeg" alt="Artwork highlighted as an honorable mention in the middle school competition">
+                                </div>
+                                <h4>Honorable Mention 2</h4>
+                            </article>
+                            <article class="winner-card honorable-mention" data-animate>
+                                <div class="winner-image">
+                                    <img src="images/3rdHonorableMentionMiddleSchool.jpeg" alt="Artwork earning honorable mention recognition in the middle school competition">
+                                </div>
+                                <h4>Honorable Mention 3</h4>
+                            </article>
+                    </div>
+                    <div class="photo-gallery" data-animate>
+                        <h4>Photo Gallery</h4>
+                        <div class="photo-carousel" data-carousel>
+                            <button class="carousel-control carousel-control--prev" type="button" aria-label="Scroll to previous middle school photos" data-carousel-prev>
+                                <span aria-hidden="true">&#10094;</span>
+                            </button>
+                            <div class="carousel-track" data-carousel-track tabindex="0" aria-label="Middle school competition photo gallery">
+                                <figure class="carousel-item"><img src="images/compnathupur/1stHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 1 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/1stHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 2 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/1stPlaceHighSchoolDisplay.jpeg" alt="Competition photo 3 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/1stPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 4 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 5 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 6 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndPlaceHighSchoolDisplay.jpeg" alt="Competition photo 7 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/2ndPlaceMiddleSchoolDisplay.jpeg" alt="Competition photo 8 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 9 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 10 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdPlaceHighSchoolDisplay.jpeg" alt="Competition photo 11 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/3rdPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 12 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-19-27.jpg" alt="Competition photo 13 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-19-28.jpg" alt="Competition photo 14 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-19.jpg" alt="Competition photo 15 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20%202.jpg" alt="Competition photo 16 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20%203.jpg" alt="Competition photo 17 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20.jpg" alt="Competition photo 18 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-21%202.jpg" alt="Competition photo 19 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-21.jpg" alt="Competition photo 20 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22%202.jpg" alt="Competition photo 21 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22%203.jpg" alt="Competition photo 22 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22.jpg" alt="Competition photo 23 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23%202.jpg" alt="Competition photo 24 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23%203.jpg" alt="Competition photo 25 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23.jpg" alt="Competition photo 26 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-24.jpg" alt="Competition photo 27 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-25.jpg" alt="Competition photo 28 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26%202.jpg" alt="Competition photo 29 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26%203.jpg" alt="Competition photo 30 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26.jpg" alt="Competition photo 31 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27%202.jpg" alt="Competition photo 32 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27%203.jpg" alt="Competition photo 33 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27.jpg" alt="Competition photo 34 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-28.jpg" alt="Competition photo 35 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-57-22.jpg" alt="Competition photo 36 from Nathupur event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-22.jpg" alt="Competition photo 37 from Nathupur event"></figure>
                             </div>
-                            <h4>1st Place</h4>
-                            <p>Share the winner's name, artwork title, and a short celebration of their piece here.</p>
-                        </article>
-                        <article class="winner-card second-place" data-animate>
-                            <div class="winner-image">
-                                <img src="images/2ndPlaceMiddleSchool.jpeg" alt="Artwork by the 2nd place middle school winner">
-                            </div>
-                            <h4>2nd Place</h4>
-                            <p>Use this placeholder to highlight the second-place artist and the story behind their work.</p>
-                        </article>
-                        <article class="winner-card third-place" data-animate>
-                            <div class="winner-image">
-                                <img src="images/3rdPlaceMiddleSchool.jpg" alt="Artwork by the 3rd place middle school winner">
-                            </div>
-                            <h4>3rd Place</h4>
-                            <p>Celebrate the third-place winner by sharing their name, inspiration, and artwork details.</p>
-                        </article>
-                        <article class="winner-card honorable-mention" data-animate>
-                            <div class="winner-image">
-                                <img src="images/1stHonorableMentionMiddleSchool.jpeg" alt="Artwork recognized with honorable mention in the middle school competition">
-                            </div>
-                            <h4>Honorable Mention 1</h4>
-                            <p>Spotlight an additional artist by replacing this text with their recognition and artwork photo.</p>
-                        </article>
-                        <article class="winner-card honorable-mention" data-animate>
-                            <div class="winner-image">
-                                <img src="images/2ndHonorableMentionMiddleSchool.jpeg" alt="Artwork highlighted as an honorable mention in the middle school competition">
-                            </div>
-                            <h4>Honorable Mention 2</h4>
-                            <p>Use this card to feature another standout submission from the competition.</p>
-                        </article>
-                        <article class="winner-card honorable-mention" data-animate>
-                            <div class="winner-image">
-                                <img src="images/3rdHonorableMentionMiddleSchool.jpeg" alt="Artwork earning honorable mention recognition in the middle school competition">
-                            </div>
-                            <h4>Honorable Mention 3</h4>
-                            <p>Share the story of this honoree by adding their photo, name, and the highlights of their artwork.</p>
-                        </article>
+                            <button class="carousel-control carousel-control--next" type="button" aria-label="Scroll to next middle school photos" data-carousel-next>
+                                <span aria-hidden="true">&#10095;</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -278,50 +321,93 @@
                 </div>
                 <div class="journey-subsection journey-subsection--winners" data-animate>
                     <h3>Winner Gallery</h3>
-                    <p class="journey-subsection-lead">Showcase the high school winners and honorable mentions once selections are made.</p>
                     <div class="winner-grid" data-animate-group>
                         <article class="winner-card first-place" data-animate>
                             <div class="winner-image">
                                 <img src="images/1stPlaceHighSchool.jpeg" alt="Artwork from the first-place high school winner">
                             </div>
                             <h4>1st Place</h4>
-                            <p>Our first-place artist captured the spirit of movement with expressive linework and confident shading that drew the judges in immediately.</p>
                         </article>
                         <article class="winner-card second-place" data-animate>
                             <div class="winner-image">
                                 <img src="images/2ndPlaceHighSchool.jpeg" alt="Artwork from the second-place high school winner">
                             </div>
                             <h4>2nd Place</h4>
-                            <p>The second-place piece layers intricate details to portray everyday motion, demonstrating remarkable patience and craft.</p>
                         </article>
                         <article class="winner-card third-place" data-animate>
                             <div class="winner-image">
                                 <img src="images/3rdPlaceHighSchool.jpeg" alt="Artwork from the third-place high school winner">
                             </div>
                             <h4>3rd Place</h4>
-                            <p>Dynamic gestures and a bold perspective earned this artwork third place and showcased a thoughtful interpretation of the prompt.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/1stHonorableMentionHighSchool.jpeg" alt="Artwork from the honorable mention high school artist">
                             </div>
                             <h4>Honorable Mention 1</h4>
-                            <p>This honorable mention blends delicate textures and storytelling, offering a memorable take on movement in daily life.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/2ndHonorableMentionHighSchool.jpeg" alt="Artwork from the second honorable mention high school artist">
                             </div>
                             <h4>Honorable Mention 2</h4>
-                            <p>Soft gradients and delicate pencil work earned this artist a nod for the way their composition balances energy and calm.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/3rdHonorableMentionHighSchool.jpeg" alt="Artwork from the third honorable mention high school artist">
                             </div>
                             <h4>Honorable Mention 3</h4>
-                            <p>A vibrant colour palette and expressive marks made this piece stand out as a joyful celebration of motion.</p>
                         </article>
+                    </div>
+                    <div class="photo-gallery" data-animate>
+                        <h4>Photo Gallery</h4>
+                        <div class="photo-carousel" data-carousel>
+                            <button class="carousel-control carousel-control--prev" type="button" aria-label="Scroll to previous high school photos" data-carousel-prev>
+                                <span aria-hidden="true">&#10094;</span>
+                            </button>
+                            <div class="carousel-track" data-carousel-track tabindex="0" aria-label="High school competition photo gallery">
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-23%202.jpg" alt="Competition photo 1 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-23.jpg" alt="Competition photo 2 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-20%202.jpg" alt="Competition photo 3 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-20.jpg" alt="Competition photo 4 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21%202.jpg" alt="Competition photo 5 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21%203.jpg" alt="Competition photo 6 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21.jpg" alt="Competition photo 7 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-32%202.jpg" alt="Competition photo 8 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-32.jpg" alt="Competition photo 9 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33%202.jpg" alt="Competition photo 10 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33%203.jpg" alt="Competition photo 11 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33.jpg" alt="Competition photo 12 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-34%202.jpg" alt="Competition photo 13 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-34.jpg" alt="Competition photo 14 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35%202.jpg" alt="Competition photo 15 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35%203.jpg" alt="Competition photo 16 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35.jpg" alt="Competition photo 17 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36%202.jpg" alt="Competition photo 18 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36%203.jpg" alt="Competition photo 19 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36.jpg" alt="Competition photo 20 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37%202.jpg" alt="Competition photo 21 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37%203.jpg" alt="Competition photo 22 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37.jpg" alt="Competition photo 23 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-38%203.jpg" alt="Competition photo 24 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-39%202.jpg" alt="Competition photo 25 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-39.jpg" alt="Competition photo 26 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40%202.jpg" alt="Competition photo 27 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40%203.jpg" alt="Competition photo 28 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40.jpg" alt="Competition photo 29 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-10-12-31.jpg" alt="Competition photo 30 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-10-43-01.jpg" alt="Competition photo 31 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-13.jpg" alt="Competition photo 32 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-14%202.jpg" alt="Competition photo 33 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-14.jpg" alt="Competition photo 34 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-15.jpg" alt="Competition photo 35 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-12-34-54.jpg" alt="Competition photo 36 from Nathupur high school event"></figure>
+                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-12-35-11.jpg" alt="Competition photo 37 from Nathupur high school event"></figure>
+                            </div>
+                            <button class="carousel-control carousel-control--next" type="button" aria-label="Scroll to next high school photos" data-carousel-next>
+                                <span aria-hidden="true">&#10095;</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
                 <div class="journey-callout" data-animate>


### PR DESCRIPTION
## Summary
- remove the remaining placeholder copy from both winner galleries
- restyle the competition photo carousels for larger landscape tiles with responsive sizing
- add infinite looping controls and a lightbox so carousel images can expand to full-screen

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68d48d3040248330ae484c65468c9c25