### PR TITLE
Revamp winner galleries and photo experience

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2241,119 +2241,158 @@ footer::before {
     color: var(--secondary-color);
 }
 
-.photo-carousel {
+.photo-gallery-grid {
     position: relative;
-    padding: 0 48px;
-}
-
-.carousel-track {
     display: grid;
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(220px, min(32vw, 320px));
-    gap: 18px;
-    overflow-x: auto;
-    padding: 12px 0 12px 12px;
-    scroll-snap-type: x mandatory;
-    scroll-behavior: smooth;
-    -webkit-overflow-scrolling: touch;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+    padding: 28px;
+    border-radius: 22px;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: var(--box-shadow-hover);
+}
+
+.photo-gallery-item {
+    position: relative;
     border-radius: 18px;
-    background: rgba(255, 255, 255, 0.85);
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
-}
-
-.carousel-track:focus {
-    outline: 3px solid rgba(229, 157, 131, 0.45);
-    outline-offset: 4px;
-}
-
-.carousel-track::-webkit-scrollbar {
-    display: none;
-}
-
-.carousel-item {
-    scroll-snap-align: center;
-    border-radius: 16px;
     overflow: hidden;
     background: var(--white);
     box-shadow: var(--box-shadow);
-    border: 1px solid rgba(0, 0, 0, 0.05);
+    cursor: zoom-in;
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
 }
 
-.carousel-item img {
-    width: 100%;
+.photo-gallery-item:hover,
+.photo-gallery-item:focus-visible {
+    transform: translateY(-8px);
+    box-shadow: var(--box-shadow-hover);
+    outline: none;
+}
+
+.photo-gallery-item:focus-visible::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border: 3px solid rgba(229, 157, 131, 0.6);
+    border-radius: 18px;
+    pointer-events: none;
+}
+
+.photo-gallery-item img {
     display: block;
+    width: 100%;
     height: 100%;
+    aspect-ratio: 3 / 2;
     object-fit: cover;
 }
 
-.carousel-control {
+.photo-gallery-sentinel {
+    width: 100%;
+    height: 1px;
+    grid-column: 1 / -1;
+}
+
+body.gallery-open {
+    overflow: hidden;
+}
+
+.photo-gallery-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(16px, 4vw, 56px);
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity var(--transition-medium), visibility var(--transition-medium);
+    z-index: 1200;
+}
+
+.photo-gallery-modal.is-active {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+.photo-gallery-modal__backdrop {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    background: var(--primary-color);
-    color: var(--white);
+    inset: 0;
+}
+
+.photo-gallery-modal__dialog {
+    position: relative;
+    max-width: min(1200px, 96vw);
+    width: 100%;
+    z-index: 1;
+}
+
+.photo-gallery-modal__figure {
+    margin: 0;
+    background: var(--white);
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: var(--box-shadow-hover);
+}
+
+.photo-gallery-modal__figure img {
+    width: 100%;
+    height: auto;
+    max-height: 80vh;
+    display: block;
+    object-fit: contain;
+}
+
+.photo-gallery-modal__figure figcaption {
+    padding: 18px 24px;
+    font-size: 1rem;
+    color: var(--text-muted);
+}
+
+.photo-gallery-modal__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    width: 44px;
+    height: 44px;
     border: none;
     border-radius: 50%;
-    width: 42px;
-    height: 42px;
+    background: rgba(0, 0, 0, 0.65);
+    color: var(--white);
+    font-size: 1.6rem;
+    line-height: 1;
     display: grid;
     place-items: center;
     cursor: pointer;
-    box-shadow: var(--box-shadow);
     transition: transform var(--transition-medium), background var(--transition-medium);
 }
 
-.carousel-control:hover,
-.carousel-control:focus-visible {
+.photo-gallery-modal__close:hover,
+.photo-gallery-modal__close:focus-visible {
+    transform: scale(1.05);
     background: var(--secondary-color);
-    transform: translateY(-50%) scale(1.05);
-}
-
-.carousel-control:disabled {
-    opacity: 0.45;
-    cursor: default;
-    background: rgba(0, 0, 0, 0.2);
-    box-shadow: none;
-}
-
-.carousel-control:disabled:hover,
-.carousel-control:disabled:focus-visible {
-    transform: translateY(-50%);
-    background: rgba(0, 0, 0, 0.2);
-}
-
-.carousel-control span {
-    font-size: 1.6rem;
-    line-height: 1;
-}
-
-.carousel-control--prev {
-    left: 0;
-}
-
-.carousel-control--next {
-    right: 0;
+    outline: none;
 }
 
 @media (max-width: 1024px) {
-    .photo-carousel {
-        padding: 0 36px;
+    .photo-gallery-grid {
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 20px;
+        padding: 24px;
     }
 }
 
 @media (max-width: 768px) {
-    .photo-carousel {
-        padding: 0 24px;
+    .photo-gallery-grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 18px;
+        padding: 20px;
     }
 
-    .carousel-track {
-        grid-auto-columns: minmax(200px, 72%);
-        padding: 12px 0;
-    }
-
-    .carousel-control {
-        width: 36px;
-        height: 36px;
+    .photo-gallery-modal__figure img {
+        max-height: 70vh;
     }
 }
 
@@ -2362,13 +2401,13 @@ footer::before {
         margin-top: 36px;
     }
 
-    .photo-carousel {
-        padding: 0 16px;
+    .photo-gallery-grid {
+        grid-template-columns: 1fr;
+        padding: 18px;
     }
 
-    .carousel-track {
-        grid-auto-columns: minmax(180px, 86%);
-        gap: 14px;
+    .photo-gallery-modal__figure figcaption {
+        padding: 16px;
     }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -459,70 +459,165 @@ document.addEventListener('DOMContentLoaded', function() {
 
     enhancePrizes();
 
-    // Photo carousel controls
-    document.querySelectorAll('[data-carousel]').forEach(carousel => {
-        const track = carousel.querySelector('[data-carousel-track]');
-        if (!track) {
-            return;
-        }
+    // Photo gallery enhancements
+    const galleryContainers = document.querySelectorAll('[data-gallery]');
+    if (galleryContainers.length) {
+        const body = document.body;
+        const galleryModal = document.createElement('div');
+        galleryModal.className = 'photo-gallery-modal';
+        galleryModal.setAttribute('aria-hidden', 'true');
+        galleryModal.innerHTML = `
+            <div class="photo-gallery-modal__backdrop" data-gallery-close></div>
+            <div class="photo-gallery-modal__dialog" role="dialog" aria-modal="true" aria-label="Expanded gallery image">
+                <button type="button" class="photo-gallery-modal__close" data-gallery-close aria-label="Close gallery view">&times;</button>
+                <figure class="photo-gallery-modal__figure">
+                    <img alt="">
+                    <figcaption></figcaption>
+                </figure>
+            </div>
+        `;
+        body.appendChild(galleryModal);
 
-        const prevButton = carousel.querySelector('[data-carousel-prev]');
-        const nextButton = carousel.querySelector('[data-carousel-next]');
-        let scrollAnimationFrame = null;
+        const modalImage = galleryModal.querySelector('img');
+        const modalCaption = galleryModal.querySelector('figcaption');
+        const closeControls = galleryModal.querySelectorAll('[data-gallery-close]');
+        let previouslyFocusedElement = null;
 
-        const getScrollStep = () => track.clientWidth * 0.8;
-
-        const updateControls = () => {
-            const maxScroll = track.scrollWidth - track.clientWidth;
-            if (prevButton) {
-                prevButton.disabled = track.scrollLeft <= 1;
-            }
-            if (nextButton) {
-                nextButton.disabled = track.scrollLeft >= (maxScroll - 1);
+        const closeModal = () => {
+            galleryModal.classList.remove('is-active');
+            galleryModal.setAttribute('aria-hidden', 'true');
+            body.classList.remove('gallery-open');
+            modalImage.removeAttribute('src');
+            modalImage.removeAttribute('alt');
+            modalCaption.textContent = '';
+            if (previouslyFocusedElement) {
+                previouslyFocusedElement.focus();
+                previouslyFocusedElement = null;
             }
         };
 
-        const scheduleUpdate = () => {
-            if (scrollAnimationFrame) {
-                cancelAnimationFrame(scrollAnimationFrame);
+        const openModal = (image) => {
+            if (!image) {
+                return;
             }
-            scrollAnimationFrame = requestAnimationFrame(updateControls);
+
+            modalImage.src = image.currentSrc || image.src;
+            modalImage.alt = image.alt || '';
+            modalCaption.textContent = image.alt || '';
+            previouslyFocusedElement = document.activeElement;
+            galleryModal.classList.add('is-active');
+            galleryModal.setAttribute('aria-hidden', 'false');
+            body.classList.add('gallery-open');
+            const closeButton = galleryModal.querySelector('.photo-gallery-modal__close');
+            if (closeButton) {
+                closeButton.focus();
+            }
         };
 
-        const scrollByAmount = direction => {
-            track.scrollBy({
-                left: direction * getScrollStep(),
-                behavior: reduceMotion ? 'auto' : 'smooth'
-            });
-        };
+        closeControls.forEach(control => {
+            control.addEventListener('click', closeModal);
+        });
 
-        if (prevButton) {
-            prevButton.addEventListener('click', () => {
-                scrollByAmount(-1);
-            });
-        }
-
-        if (nextButton) {
-            nextButton.addEventListener('click', () => {
-                scrollByAmount(1);
-            });
-        }
-
-        track.addEventListener('scroll', scheduleUpdate, { passive: true });
-
-        track.addEventListener('keydown', event => {
-            if (event.key === 'ArrowLeft') {
-                event.preventDefault();
-                scrollByAmount(-1);
-            } else if (event.key === 'ArrowRight') {
-                event.preventDefault();
-                scrollByAmount(1);
+        galleryModal.addEventListener('keydown', event => {
+            if (event.key === 'Escape') {
+                closeModal();
             }
         });
 
-        window.addEventListener('resize', scheduleUpdate);
-        updateControls();
-    });
+        galleryModal.addEventListener('click', event => {
+            if (event.target === galleryModal || event.target.classList.contains('photo-gallery-modal__backdrop')) {
+                closeModal();
+            }
+        });
+
+        const activateFigure = figure => {
+            if (!figure) {
+                return;
+            }
+
+            figure.setAttribute('role', 'button');
+            figure.setAttribute('tabindex', '0');
+
+            const figureImage = figure.querySelector('img');
+            const activate = () => {
+                openModal(figureImage);
+            };
+
+            if (figureImage) {
+                const label = figureImage.alt || 'View gallery image';
+                figure.setAttribute('aria-label', label);
+            }
+
+            figure.addEventListener('click', activate);
+            figure.addEventListener('keydown', event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    activate();
+                }
+            });
+        };
+
+        galleryContainers.forEach(container => {
+            const galleryLabel = container.getAttribute('data-gallery-label');
+            if (galleryLabel) {
+                container.setAttribute('aria-label', galleryLabel);
+            }
+            container.setAttribute('role', 'list');
+
+            const baseFigures = Array.from(container.querySelectorAll('[data-gallery-item]'));
+            if (!baseFigures.length) {
+                return;
+            }
+            const sentinel = document.createElement('div');
+            sentinel.className = 'photo-gallery-sentinel';
+            sentinel.setAttribute('aria-hidden', 'true');
+            container.appendChild(sentinel);
+
+            const templateFigures = baseFigures.map(figure => figure.cloneNode(true));
+
+            const appendClones = () => {
+                const fragment = document.createDocumentFragment();
+                templateFigures.forEach(templateFigure => {
+                    const clone = templateFigure.cloneNode(true);
+                    activateFigure(clone);
+                    fragment.appendChild(clone);
+                });
+                container.insertBefore(fragment, sentinel);
+            };
+
+            let loadingMore = false;
+            let observer;
+            const scheduleAppend = () => {
+                if (loadingMore) {
+                    return;
+                }
+                loadingMore = true;
+                requestAnimationFrame(() => {
+                    appendClones();
+                    loadingMore = false;
+                    if (observer) {
+                        observer.observe(sentinel);
+                    }
+                });
+            };
+
+            observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        observer.unobserve(sentinel);
+                        scheduleAppend();
+                    }
+                });
+            }, {
+                root: null,
+                rootMargin: '0px 0px 200px',
+                threshold: 0.1
+            });
+
+            baseFigures.forEach(figure => activateFigure(figure));
+            observer.observe(sentinel);
+        });
+    }
 
     // Add particle effect to buttons
     const addButtonEffects = function() {

--- a/our-journey.html
+++ b/our-journey.html
@@ -166,85 +166,72 @@
                                 <img src="images/2ndPlaceMiddleSchool.jpeg" alt="Artwork by the 2nd place middle school winner">
                             </div>
                             <h4>2nd Place</h4>
-                            <p>Use this placeholder to highlight the second-place artist and the story behind their work.</p>
                         </article>
                         <article class="winner-card third-place" data-animate>
                             <div class="winner-image">
                                 <img src="images/3rdPlaceMiddleSchool.jpg" alt="Artwork by the 3rd place middle school winner">
                             </div>
                             <h4>3rd Place</h4>
-                            <p>Celebrate the third-place winner by sharing their name, inspiration, and artwork details.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/1stHonorableMentionMiddleSchool.jpeg" alt="Artwork recognized with honorable mention in the middle school competition">
                             </div>
                             <h4>Honorable Mention 1</h4>
-                            <p>Spotlight an additional artist by replacing this text with their recognition and artwork photo.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/2ndHonorableMentionMiddleSchool.jpeg" alt="Artwork highlighted as an honorable mention in the middle school competition">
                             </div>
                             <h4>Honorable Mention 2</h4>
-                            <p>Use this card to feature another standout submission from the competition.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/3rdHonorableMentionMiddleSchool.jpeg" alt="Artwork earning honorable mention recognition in the middle school competition">
                             </div>
                             <h4>Honorable Mention 3</h4>
-                            <p>Share the story of this honoree by adding their photo, name, and the highlights of their artwork.</p>
                         </article>
                     </div>
                     <div class="photo-gallery" data-animate>
                         <h4>Photo Gallery</h4>
-                        <div class="photo-carousel" data-carousel>
-                            <button class="carousel-control carousel-control--prev" type="button" aria-label="Scroll to previous middle school photos" data-carousel-prev>
-                                <span aria-hidden="true">&#10094;</span>
-                            </button>
-                            <div class="carousel-track" data-carousel-track tabindex="0" aria-label="Middle school competition photo gallery">
-                                <figure class="carousel-item"><img src="images/compnathupur/1stHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 1 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/1stHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 2 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/1stPlaceHighSchoolDisplay.jpeg" alt="Competition photo 3 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/1stPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 4 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/2ndHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 5 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/2ndHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 6 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/2ndPlaceHighSchoolDisplay.jpeg" alt="Competition photo 7 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/2ndPlaceMiddleSchoolDisplay.jpeg" alt="Competition photo 8 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/3rdHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 9 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/3rdHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 10 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/3rdPlaceHighSchoolDisplay.jpeg" alt="Competition photo 11 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/3rdPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 12 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-19-27.jpg" alt="Competition photo 13 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-19-28.jpg" alt="Competition photo 14 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-19.jpg" alt="Competition photo 15 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20%202.jpg" alt="Competition photo 16 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20%203.jpg" alt="Competition photo 17 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-20.jpg" alt="Competition photo 18 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-21%202.jpg" alt="Competition photo 19 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-21.jpg" alt="Competition photo 20 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22%202.jpg" alt="Competition photo 21 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22%203.jpg" alt="Competition photo 22 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-22.jpg" alt="Competition photo 23 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23%202.jpg" alt="Competition photo 24 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23%203.jpg" alt="Competition photo 25 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-23.jpg" alt="Competition photo 26 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-24.jpg" alt="Competition photo 27 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-25.jpg" alt="Competition photo 28 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26%202.jpg" alt="Competition photo 29 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26%203.jpg" alt="Competition photo 30 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-26.jpg" alt="Competition photo 31 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27%202.jpg" alt="Competition photo 32 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27%203.jpg" alt="Competition photo 33 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-27.jpg" alt="Competition photo 34 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-56-28.jpg" alt="Competition photo 35 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-06-57-22.jpg" alt="Competition photo 36 from Nathupur event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-22.jpg" alt="Competition photo 37 from Nathupur event"></figure>
-                            </div>
-                            <button class="carousel-control carousel-control--next" type="button" aria-label="Scroll to next middle school photos" data-carousel-next>
-                                <span aria-hidden="true">&#10095;</span>
-                            </button>
+                        <div class="photo-gallery-grid" data-gallery data-gallery-label="Middle school competition photo gallery">
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/1stHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 1 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/1stHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 2 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/1stPlaceHighSchoolDisplay.jpeg" alt="Competition photo 3 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/1stPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 4 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/2ndHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 5 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/2ndHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 6 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/2ndPlaceHighSchoolDisplay.jpeg" alt="Competition photo 7 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/2ndPlaceMiddleSchoolDisplay.jpeg" alt="Competition photo 8 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/3rdHonorableMentionHighSchoolDisplay.jpeg" alt="Competition photo 9 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/3rdHonorableMentionMiddleSchoolDisplay.jpeg" alt="Competition photo 10 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/3rdPlaceHighSchoolDisplay.jpeg" alt="Competition photo 11 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/3rdPlaceMiddleSchoolDisplay.jpg" alt="Competition photo 12 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-19-27.jpg" alt="Competition photo 13 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-19-28.jpg" alt="Competition photo 14 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-19.jpg" alt="Competition photo 15 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-20%202.jpg" alt="Competition photo 16 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-20%203.jpg" alt="Competition photo 17 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-20.jpg" alt="Competition photo 18 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-21%202.jpg" alt="Competition photo 19 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-21.jpg" alt="Competition photo 20 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-22%202.jpg" alt="Competition photo 21 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-22%203.jpg" alt="Competition photo 22 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-22.jpg" alt="Competition photo 23 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-23%202.jpg" alt="Competition photo 24 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-23%203.jpg" alt="Competition photo 25 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-23.jpg" alt="Competition photo 26 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-24.jpg" alt="Competition photo 27 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-25.jpg" alt="Competition photo 28 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-26%202.jpg" alt="Competition photo 29 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-26%203.jpg" alt="Competition photo 30 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-26.jpg" alt="Competition photo 31 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-27%202.jpg" alt="Competition photo 32 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-27%203.jpg" alt="Competition photo 33 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-27.jpg" alt="Competition photo 34 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-56-28.jpg" alt="Competition photo 35 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-06-57-22.jpg" alt="Competition photo 36 from Nathupur event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-53-22.jpg" alt="Competition photo 37 from Nathupur event"></figure>
                         </div>
                     </div>
                 </div>
@@ -333,92 +320,78 @@
                                 <img src="images/1stPlaceHighSchool.jpeg" alt="Artwork from the first-place high school winner">
                             </div>
                             <h4>1st Place</h4>
-                            <p>Our first-place artist captured the spirit of movement with expressive linework and confident shading that drew the judges in immediately.</p>
                         </article>
                         <article class="winner-card second-place" data-animate>
                             <div class="winner-image">
                                 <img src="images/2ndPlaceHighSchool.jpeg" alt="Artwork from the second-place high school winner">
                             </div>
                             <h4>2nd Place</h4>
-                            <p>The second-place piece layers intricate details to portray everyday motion, demonstrating remarkable patience and craft.</p>
                         </article>
                         <article class="winner-card third-place" data-animate>
                             <div class="winner-image">
                                 <img src="images/3rdPlaceHighSchool.jpeg" alt="Artwork from the third-place high school winner">
                             </div>
                             <h4>3rd Place</h4>
-                            <p>Dynamic gestures and a bold perspective earned this artwork third place and showcased a thoughtful interpretation of the prompt.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/1stHonorableMentionHighSchool.jpeg" alt="Artwork from the honorable mention high school artist">
                             </div>
                             <h4>Honorable Mention 1</h4>
-                            <p>This honorable mention blends delicate textures and storytelling, offering a memorable take on movement in daily life.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/2ndHonorableMentionHighSchool.jpeg" alt="Artwork from the second honorable mention high school artist">
                             </div>
                             <h4>Honorable Mention 2</h4>
-                            <p>Soft gradients and delicate pencil work earned this artist a nod for the way their composition balances energy and calm.</p>
                         </article>
                         <article class="winner-card honorable-mention" data-animate>
                             <div class="winner-image">
                                 <img src="images/3rdHonorableMentionHighSchool.jpeg" alt="Artwork from the third honorable mention high school artist">
                             </div>
                             <h4>Honorable Mention 3</h4>
-                            <p>A vibrant colour palette and expressive marks made this piece stand out as a joyful celebration of motion.</p>
                         </article>
                     </div>
                     <div class="photo-gallery" data-animate>
                         <h4>Photo Gallery</h4>
-                        <div class="photo-carousel" data-carousel>
-                            <button class="carousel-control carousel-control--prev" type="button" aria-label="Scroll to previous high school photos" data-carousel-prev>
-                                <span aria-hidden="true">&#10094;</span>
-                            </button>
-                            <div class="carousel-track" data-carousel-track tabindex="0" aria-label="High school competition photo gallery">
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-23%202.jpg" alt="Competition photo 1 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-53-23.jpg" alt="Competition photo 2 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-20%202.jpg" alt="Competition photo 3 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-20.jpg" alt="Competition photo 4 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21%202.jpg" alt="Competition photo 5 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21%203.jpg" alt="Competition photo 6 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-21.jpg" alt="Competition photo 7 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-32%202.jpg" alt="Competition photo 8 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-32.jpg" alt="Competition photo 9 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33%202.jpg" alt="Competition photo 10 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33%203.jpg" alt="Competition photo 11 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-33.jpg" alt="Competition photo 12 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-34%202.jpg" alt="Competition photo 13 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-34.jpg" alt="Competition photo 14 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35%202.jpg" alt="Competition photo 15 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35%203.jpg" alt="Competition photo 16 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-35.jpg" alt="Competition photo 17 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36%202.jpg" alt="Competition photo 18 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36%203.jpg" alt="Competition photo 19 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-36.jpg" alt="Competition photo 20 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37%202.jpg" alt="Competition photo 21 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37%203.jpg" alt="Competition photo 22 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-37.jpg" alt="Competition photo 23 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-38%203.jpg" alt="Competition photo 24 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-39%202.jpg" alt="Competition photo 25 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-39.jpg" alt="Competition photo 26 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40%202.jpg" alt="Competition photo 27 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40%203.jpg" alt="Competition photo 28 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-09-55-40.jpg" alt="Competition photo 29 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-10-12-31.jpg" alt="Competition photo 30 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-10-43-01.jpg" alt="Competition photo 31 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-13.jpg" alt="Competition photo 32 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-14%202.jpg" alt="Competition photo 33 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-14.jpg" alt="Competition photo 34 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-11-47-15.jpg" alt="Competition photo 35 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-12-34-54.jpg" alt="Competition photo 36 from Nathupur high school event"></figure>
-                                <figure class="carousel-item"><img src="images/compnathupur/PHOTO-2025-09-24-12-35-11.jpg" alt="Competition photo 37 from Nathupur high school event"></figure>
-                            </div>
-                            <button class="carousel-control carousel-control--next" type="button" aria-label="Scroll to next high school photos" data-carousel-next>
-                                <span aria-hidden="true">&#10095;</span>
-                            </button>
+                        <div class="photo-gallery-grid" data-gallery data-gallery-label="High school competition photo gallery">
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-53-23%202.jpg" alt="Competition photo 1 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-53-23.jpg" alt="Competition photo 2 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-20%202.jpg" alt="Competition photo 3 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-20.jpg" alt="Competition photo 4 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-21%202.jpg" alt="Competition photo 5 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-21%203.jpg" alt="Competition photo 6 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-21.jpg" alt="Competition photo 7 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-32%202.jpg" alt="Competition photo 8 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-32.jpg" alt="Competition photo 9 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-33%202.jpg" alt="Competition photo 10 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-33%203.jpg" alt="Competition photo 11 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-33.jpg" alt="Competition photo 12 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-34%202.jpg" alt="Competition photo 13 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-34.jpg" alt="Competition photo 14 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-35%202.jpg" alt="Competition photo 15 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-35%203.jpg" alt="Competition photo 16 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-35.jpg" alt="Competition photo 17 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-36%202.jpg" alt="Competition photo 18 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-36%203.jpg" alt="Competition photo 19 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-36.jpg" alt="Competition photo 20 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-37%202.jpg" alt="Competition photo 21 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-37%203.jpg" alt="Competition photo 22 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-37.jpg" alt="Competition photo 23 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-38%203.jpg" alt="Competition photo 24 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-39%202.jpg" alt="Competition photo 25 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-39.jpg" alt="Competition photo 26 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-40%202.jpg" alt="Competition photo 27 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-40%203.jpg" alt="Competition photo 28 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-09-55-40.jpg" alt="Competition photo 29 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-10-12-31.jpg" alt="Competition photo 30 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-10-43-01.jpg" alt="Competition photo 31 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-11-47-13.jpg" alt="Competition photo 32 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-11-47-14%202.jpg" alt="Competition photo 33 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-11-47-14.jpg" alt="Competition photo 34 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-11-47-15.jpg" alt="Competition photo 35 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-12-34-54.jpg" alt="Competition photo 36 from Nathupur high school event"></figure>
+                                <figure class="photo-gallery-item" role="button" tabindex="0" data-gallery-item><img loading="lazy" src="images/compnathupur/PHOTO-2025-09-24-12-35-11.jpg" alt="Competition photo 37 from Nathupur high school event"></figure>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove placeholder copy beneath all middle and high school winner and honorable mention cards
- rebuild the school photo galleries into responsive grids with landscape crops, modal zoom, and infinite scrolling
- add styling for the enlarged photo modal, zoom affordances, and scroll locking while the gallery is open

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68d4944da84c8330b999eacacfc48708