### PR TITLE
Adjust carousel layout for single landscape slides

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2230,13 +2230,13 @@ footer::before {
 }
 
 .photo-gallery {
-    margin-top: 48px;
+    margin-top: 40px;
 }
 
 .photo-gallery h4 {
     font-family: var(--font-heading);
     font-size: clamp(1.3rem, 1.1rem + 0.5vw, 1.6rem);
-    margin-bottom: 18px;
+    margin-bottom: 22px;
     text-align: center;
     color: var(--secondary-color);
 }
@@ -2244,24 +2244,22 @@ footer::before {
 
 .photo-carousel {
     position: relative;
-    padding: 0 clamp(64px, 8vw, 140px);
+    padding: 0 clamp(48px, 6vw, 96px);
+    max-width: min(92vw, 940px);
+    margin: 0 auto;
 }
 
 .carousel-track {
     display: grid;
     grid-auto-flow: column;
-    grid-auto-columns: minmax(720px, min(90vw, 1280px));
-    gap: 32px;
-    grid-auto-columns: minmax(400px, min(60vw, 720px));
-    gap: 24px;
+    grid-auto-columns: 100%;
+    gap: 0;
     overflow-x: auto;
-    padding: 20px 0 20px 20px;
+    padding: clamp(18px, 4vw, 28px) 0;
+    scroll-padding: 0;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
     -webkit-overflow-scrolling: touch;
-    border-radius: 18px;
-    background: rgba(255, 255, 255, 0.9);
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
 }
 
 .carousel-track:focus {
@@ -2275,14 +2273,15 @@ footer::before {
 
 .carousel-item {
     scroll-snap-align: center;
-    border-radius: 18px;
-    overflow: hidden;
-    background: var(--white);
+    border-radius: clamp(18px, 4vw, 28px);
+    background: rgba(255, 255, 255, 0.95);
     box-shadow: var(--box-shadow);
-    border: 1px solid rgba(0, 0, 0, 0.08);
-    aspect-ratio: 16 / 9;
+    aspect-ratio: 3 / 2;
+    min-height: clamp(300px, 48vw, 560px);
     display: flex;
-    align-items: stretch;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(12px, 3vw, 22px);
 }
 
 .carousel-item img {
@@ -2290,8 +2289,10 @@ footer::before {
     display: block;
     height: 100%;
     object-fit: cover;
-    flex: 1 1 auto;
     cursor: zoom-in;
+    border-radius: clamp(14px, 3.5vw, 24px);
+    border: clamp(10px, 3vw, 16px) solid #fff;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
 }
 
 .carousel-control {
@@ -2471,9 +2472,7 @@ footer::before {
     }
 
     .carousel-track {
-        grid-auto-columns: minmax(82vw, 96vw);
-        gap: 24px;
-        padding: 18px 0 18px 18px;
+        padding: clamp(16px, 5vw, 22px) 0;
     }
 
     .gallery-modal__inner {
@@ -2493,19 +2492,9 @@ footer::before {
     }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 1024px) {
     .photo-carousel {
-        padding: 0 18px;
-    }
-
-    .carousel-track {
-        grid-auto-columns: 96vw;
-        gap: 18px;
-        padding: 12px 0 12px 12px;
-    }
-
-    .gallery-modal__figure figcaption {
-        font-size: 0.95rem;
+        padding: 0 clamp(32px, 5vw, 72px);
     }
 }
 
@@ -2522,22 +2511,17 @@ footer::before {
     right: 0;
 }
 
-@media (max-width: 1024px) {
-    .photo-carousel {
-        padding: 0 36px;
-    }
-}
-
 @media (max-width: 768px) {
     .photo-carousel {
-        padding: 0 clamp(20px, 5vw, 32px);
+        padding: 0 clamp(22px, 5vw, 32px);
     }
 
     .carousel-track {
-        grid-auto-columns: minmax(92vw, 100%);
-        padding: 14px 0;
-        grid-auto-columns: minmax(260px, 82%);
-        padding: 12px 0;
+        padding: clamp(14px, 5vw, 20px) 0;
+    }
+
+    .carousel-item {
+        min-height: clamp(240px, 60vw, 420px);
     }
 
     .carousel-control {
@@ -2548,16 +2532,24 @@ footer::before {
 
 @media (max-width: 520px) {
     .photo-gallery {
-        margin-top: 36px;
+        margin-top: 32px;
     }
 
     .photo-carousel {
-        padding: 0 16px;
+        padding: 0 clamp(16px, 6vw, 22px);
     }
 
     .carousel-track {
-        grid-auto-columns: minmax(220px, 88%);
-        gap: 14px;
+        padding: clamp(12px, 6vw, 18px) 0;
+    }
+
+    .carousel-item {
+        min-height: clamp(210px, 72vw, 360px);
+        padding: clamp(10px, 5vw, 16px);
+    }
+
+    .gallery-modal__figure figcaption {
+        font-size: 0.95rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- constrain the photo carousel track to one slide per view while keeping it centered in the gallery section
- restore a landscape presentation for gallery photos and wrap each image in an even white border for both grade levels

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d4a052a04883308d4da0e6233ce034