### PR TITLE
Ensure photo carousel displays full landscape slides

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2241,7 +2241,6 @@ footer::before {
     color: var(--secondary-color);
 }
 
-
 .photo-carousel {
     position: relative;
     padding: 0 clamp(48px, 6vw, 96px);
@@ -2256,12 +2255,7 @@ footer::before {
     grid-auto-columns: 100%;
     gap: 0;
     overflow-x: auto;
-    padding: clamp(18px, 4vw, 28px) 0;
-    scroll-padding: 0;
-    grid-auto-columns: minmax(400px, min(60vw, 720px));
-    gap: 28px;
-    overflow-x: auto;
-    padding: 24px;
+    padding: clamp(18px, 4vw, 28px) 24px;
     scroll-padding: 0 24px;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
@@ -2282,11 +2276,9 @@ footer::before {
     border-radius: clamp(18px, 4vw, 28px);
     background: rgba(255, 255, 255, 0.95);
     box-shadow: var(--box-shadow);
-    aspect-ratio: 3 / 2;
-    min-height: clamp(300px, 48vw, 560px);
     border: 1px solid rgba(0, 0, 0, 0.08);
-    aspect-ratio: 4 / 3;
-    min-height: clamp(320px, 52vw, 600px);
+    aspect-ratio: 16 / 9;
+    min-height: clamp(280px, 48vw, 520px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2295,9 +2287,9 @@ footer::before {
 
 .carousel-item img {
     width: 100%;
-    display: block;
     height: 100%;
-    object-fit: cover;
+    display: block;
+    object-fit: contain;
     cursor: zoom-in;
     border-radius: clamp(14px, 3.5vw, 24px);
     border: clamp(10px, 3vw, 16px) solid #fff;
@@ -2481,7 +2473,8 @@ footer::before {
     }
 
     .carousel-track {
-        padding: clamp(16px, 5vw, 22px) 0;
+        padding: clamp(16px, 5vw, 22px) clamp(20px, 6vw, 32px);
+        scroll-padding: 0 clamp(20px, 6vw, 32px);
     }
 
     .gallery-modal__inner {
@@ -2526,23 +2519,12 @@ footer::before {
     }
 
     .carousel-track {
-        padding: clamp(14px, 5vw, 20px) 0;
+        padding: clamp(14px, 5vw, 20px) clamp(18px, 6vw, 24px);
+        scroll-padding: 0 clamp(18px, 6vw, 24px);
     }
 
     .carousel-item {
-        min-height: clamp(240px, 60vw, 420px);
-        padding: 0 clamp(24px, 5vw, 36px);
-    }
-
-    .carousel-track {
-        grid-auto-columns: minmax(280px, 82%);
-        gap: 22px;
-        padding: 18px;
-        scroll-padding: 0 18px;
-    }
-
-    .carousel-item {
-        min-height: clamp(260px, 58vw, 520px);
+        min-height: clamp(240px, 58vw, 460px);
     }
 
     .carousel-control {
@@ -2561,24 +2543,13 @@ footer::before {
     }
 
     .carousel-track {
-        padding: clamp(12px, 6vw, 18px) 0;
+        padding: clamp(12px, 6vw, 18px) clamp(16px, 7vw, 22px);
+        scroll-padding: 0 clamp(16px, 7vw, 22px);
     }
 
     .carousel-item {
-        min-height: clamp(210px, 72vw, 360px);
+        min-height: clamp(210px, 70vw, 360px);
         padding: clamp(10px, 5vw, 16px);
-        padding: 0 18px;
-    }
-
-    .carousel-track {
-        grid-auto-columns: minmax(220px, 88%);
-        gap: 16px;
-        padding: 16px;
-        scroll-padding: 0 16px;
-    }
-
-    .carousel-item {
-        min-height: clamp(220px, 68vw, 380px);
     }
 
     .gallery-modal__figure figcaption {


### PR DESCRIPTION
## Summary
- enforce single-slide layout in the photo carousel so only one image shows at a time and keep full landscape framing
- switch carousel images to `object-fit: contain` with landscape aspect ratio to prevent cropping while preserving borders
- tune responsive padding so slide spacing remains centered across breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4a5b200dc8330a09d77cfda5d9ea0