### PR TITLE
Fix photo gallery spacing and navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2243,10 +2243,12 @@ footer::before {
 
 .photo-carousel {
     position: relative;
-    padding: 0 clamp(48px, 6vw, 96px);
     max-width: min(92vw, 940px);
     margin: 0 auto;
-    padding: 0 clamp(56px, 7vw, 132px);
+    padding: clamp(32px, 6vw, 56px);
+    background: var(--white);
+    border-radius: clamp(24px, 5vw, 36px);
+    box-shadow: var(--box-shadow);
 }
 
 .carousel-track {
@@ -2255,11 +2257,9 @@ footer::before {
     grid-auto-columns: minmax(0, 100%);
     gap: 0;
     overflow-x: auto;
-    padding: clamp(18px, 4vw, 28px) 0;
-    scroll-padding: 0;
-    scroll-padding-inline: 0;
-    padding: clamp(18px, 4vw, 28px) 24px;
-    scroll-padding: 0 24px;
+    justify-items: center;
+    padding: 0 clamp(24px, 4.5vw, 36px);
+    scroll-padding: 0 clamp(24px, 4.5vw, 36px);
     scroll-snap-type: x mandatory;
     scroll-snap-stop: always;
     scroll-behavior: smooth;
@@ -2277,6 +2277,7 @@ footer::before {
 
 .carousel-item {
     scroll-snap-align: center;
+    width: min(100%, 720px);
     border-radius: clamp(18px, 4vw, 28px);
     background: rgba(255, 255, 255, 0.95);
     box-shadow: var(--box-shadow);
@@ -2315,6 +2316,8 @@ footer::before {
     cursor: pointer;
     box-shadow: var(--box-shadow);
     transition: transform var(--transition-medium), background var(--transition-medium);
+    z-index: 2;
+    pointer-events: auto;
 }
 
 .carousel-control[disabled] {
@@ -2503,7 +2506,7 @@ footer::before {
 
 @media (max-width: 1024px) {
     .photo-carousel {
-        padding: 0 clamp(32px, 5vw, 72px);
+        padding: clamp(28px, 6vw, 44px);
     }
 }
 
@@ -2513,23 +2516,20 @@ footer::before {
 }
 
 .carousel-control--prev {
-    left: 0;
+    left: clamp(16px, 3vw, 28px);
 }
 
 .carousel-control--next {
-    right: 0;
+    right: clamp(16px, 3vw, 28px);
 }
 
 @media (max-width: 768px) {
     .photo-carousel {
-        padding: 0 clamp(22px, 5vw, 32px);
+        padding: clamp(24px, 6vw, 36px);
     }
 
     .carousel-track {
-        padding: clamp(14px, 5vw, 20px) 0;
-        scroll-padding: 0;
-        scroll-padding-inline: 0;
-        padding: clamp(14px, 5vw, 20px) clamp(18px, 6vw, 24px);
+        padding: 0 clamp(18px, 6vw, 24px);
         scroll-padding: 0 clamp(18px, 6vw, 24px);
     }
 
@@ -2549,14 +2549,11 @@ footer::before {
     }
 
     .photo-carousel {
-        padding: 0 clamp(16px, 6vw, 22px);
+        padding: clamp(18px, 7vw, 28px);
     }
 
     .carousel-track {
-        padding: clamp(12px, 6vw, 18px) 0;
-        scroll-padding: 0;
-        scroll-padding-inline: 0;
-        padding: clamp(12px, 6vw, 18px) clamp(16px, 7vw, 22px);
+        padding: 0 clamp(16px, 7vw, 22px);
         scroll-padding: 0 clamp(16px, 7vw, 22px);
     }
 


### PR DESCRIPTION
## Summary
- wrap the photo gallery carousel with a consistent white frame to eliminate the orange bands
- center each slide and limit its width so only one image appears per gallery view
- raise the navigation arrows above the carousel content for reliable clicks on all zoom levels

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_b_68d4aeff75108330ab4ba1afe83f780d