### PR TITLE
Adjust carousel container to prevent image cropping

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2275,18 +2275,19 @@ footer::before {
 .carousel-item {
     flex: 0 0 100%;
     scroll-snap-align: center;
-    aspect-ratio: 16 / 9;
-    min-height: clamp(280px, 48vw, 520px);
     display: flex;
     align-items: center;
     justify-content: center;
     padding: clamp(12px, 3vw, 22px);
+    min-height: clamp(320px, 52vw, 640px);
 }
 
 .carousel-item img {
-    width: 100%;
-    height: 100%;
     display: block;
+    width: auto;
+    max-width: 100%;
+    height: auto;
+    max-height: min(70vh, 680px);
     object-fit: contain;
     cursor: zoom-in;
     border-radius: clamp(14px, 3.5vw, 24px);


### PR DESCRIPTION
## Summary
- allow photo carousel items to grow taller so portrait shots aren't clipped
- constrain inline images with responsive max-dimensions so they remain centered without cropping

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d4b4e84df48330888650fae8223a75