### PR TITLE
Tailor carousel frame to match image orientation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2275,23 +2275,50 @@ footer::before {
 .carousel-item {
     flex: 0 0 100%;
     scroll-snap-align: center;
-    aspect-ratio: 16 / 9;
-    min-height: clamp(280px, 48vw, 520px);
     display: flex;
     align-items: center;
     justify-content: center;
     padding: clamp(12px, 3vw, 22px);
+    min-height: clamp(260px, 45vw, 620px);
+    transition: min-height var(--transition-medium) ease;
+}
+
+.carousel-item[data-orientation="landscape"] {
+    min-height: clamp(220px, 32vw, 460px);
+}
+
+.carousel-item[data-orientation="portrait"] {
+    min-height: clamp(360px, 58vw, 760px);
+}
+
+.carousel-item[data-orientation="square"] {
+    min-height: clamp(300px, 48vw, 600px);
 }
 
 .carousel-item img {
-    width: 100%;
-    height: 100%;
     display: block;
+    width: auto;
+    max-width: 100%;
+    height: auto;
+    max-height: min(68vh, 660px);
     object-fit: contain;
     cursor: zoom-in;
     border-radius: clamp(14px, 3.5vw, 24px);
     background: var(--white);
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
+    transition: max-height var(--transition-medium) ease;
+}
+
+.carousel-item[data-orientation="landscape"] img {
+    max-height: min(56vh, 520px);
+}
+
+.carousel-item[data-orientation="portrait"] img {
+    max-height: min(84vh, 780px);
+}
+
+.carousel-item[data-orientation="square"] img {
+    max-height: min(70vh, 680px);
 }
 
 .carousel-control {

--- a/js/main.js
+++ b/js/main.js
@@ -630,6 +630,46 @@ document.addEventListener('DOMContentLoaded', function() {
         const prevButton = carousel.querySelector('[data-carousel-prev]');
         const nextButton = carousel.querySelector('[data-carousel-next]');
 
+        const orientationThreshold = 0.08;
+
+        const setItemOrientation = (item, image) => {
+            if (!item || !image) {
+                return;
+            }
+
+            const { naturalWidth, naturalHeight } = image;
+            if (!naturalWidth || !naturalHeight) {
+                return;
+            }
+
+            let orientation = 'square';
+            const ratio = naturalWidth / naturalHeight;
+            if (ratio > 1 + orientationThreshold) {
+                orientation = 'landscape';
+            } else if (ratio < 1 - orientationThreshold) {
+                orientation = 'portrait';
+            }
+
+            item.dataset.orientation = orientation;
+        };
+
+        const prepareItemOrientation = item => {
+            const image = item.querySelector('img');
+            if (!image) {
+                return;
+            }
+
+            const updateOrientation = () => setItemOrientation(item, image);
+
+            if (image.complete && image.naturalWidth && image.naturalHeight) {
+                updateOrientation();
+            } else {
+                image.addEventListener('load', updateOrientation, { once: true });
+            }
+        };
+
+        carouselItems.forEach(prepareItemOrientation);
+
         let currentIndex = 0;
         let scrollFrame = null;
         let trackPaddingLeft = 0;


### PR DESCRIPTION
## Summary
- size carousel frames dynamically by tagging items with their image orientation
- tune height constraints for portrait, landscape, and square photos so slides hug the content more closely

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d4b4e84df48330888650fae8223a75