### PR TITLE
Adjust photo carousel spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2250,16 +2250,13 @@ footer::before {
 
 .carousel-track {
     display: flex;
-    gap: 0;
+    gap: clamp(16px, 4vw, 24px);
     overflow-x: auto;
     padding: clamp(20px, 4vw, 32px);
-    border-radius: clamp(18px, 4vw, 28px);
-    background: var(--white);
     scroll-padding: clamp(20px, 4vw, 32px);
     scroll-snap-type: x mandatory;
     scroll-snap-stop: always;
     scroll-behavior: smooth;
-    box-shadow: var(--box-shadow);
     -webkit-overflow-scrolling: touch;
 }
 
@@ -2272,14 +2269,19 @@ footer::before {
     display: none;
 }
 
+
 .carousel-item {
     flex: 0 0 100%;
     scroll-snap-align: center;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: clamp(12px, 3vw, 22px);
-    min-height: clamp(320px, 52vw, 640px);
+    padding: clamp(18px, 4vw, 28px);
+    margin: 0;
+    background: var(--white);
+    border-radius: clamp(18px, 4vw, 28px);
+    box-shadow: var(--box-shadow);
+    overflow: hidden;
 }
 
 .carousel-item img {
@@ -2291,8 +2293,6 @@ footer::before {
     object-fit: contain;
     cursor: zoom-in;
     border-radius: clamp(14px, 3.5vw, 24px);
-    background: var(--white);
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
 }
 
 .carousel-control {
@@ -2524,7 +2524,7 @@ footer::before {
     }
 
     .carousel-item {
-        min-height: clamp(240px, 58vw, 460px);
+        padding: clamp(16px, 6vw, 24px);
     }
 
     .carousel-control {
@@ -2548,8 +2548,7 @@ footer::before {
     }
 
     .carousel-item {
-        min-height: clamp(210px, 70vw, 360px);
-        padding: clamp(10px, 5vw, 16px);
+        padding: clamp(14px, 7vw, 20px);
     }
 
     .gallery-modal__figure figcaption {


### PR DESCRIPTION
## Summary
- give each carousel slide its own card styling so portrait and landscape photos keep consistent white borders
- remove oversized minimum heights so the white framing hugs the images without leaking between slides
- tune responsive padding so spacing stays even across breakpoints

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d4b8ac16cc8330a38dff39acd9b9c2