### PR TITLE
Refine carousel layout and reinstate infinite loop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2241,25 +2241,25 @@ footer::before {
     color: var(--secondary-color);
 }
 
+
 .photo-carousel {
     position: relative;
-    max-width: min(92vw, 940px);
+    max-width: min(94vw, 1080px);
     margin: 0 auto;
     padding: clamp(24px, 6vw, 48px) clamp(56px, 7vw, 132px);
 }
 
 .carousel-track {
+    position: relative;
     display: flex;
-    gap: 0;
+    gap: clamp(16px, 4vw, 24px);
+    align-items: center;
     overflow-x: auto;
     padding: clamp(20px, 4vw, 32px);
-    border-radius: clamp(18px, 4vw, 28px);
-    background: var(--white);
     scroll-padding: clamp(20px, 4vw, 32px);
     scroll-snap-type: x mandatory;
     scroll-snap-stop: always;
     scroll-behavior: smooth;
-    box-shadow: var(--box-shadow);
     -webkit-overflow-scrolling: touch;
 }
 
@@ -2272,27 +2272,63 @@ footer::before {
     display: none;
 }
 
+
 .carousel-item {
+    --carousel-aspect: 3 / 4;
+    --carousel-max-visual-width: min(78vw, 560px);
     flex: 0 0 100%;
     scroll-snap-align: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: clamp(12px, 3vw, 22px);
-    min-height: clamp(320px, 52vw, 640px);
+    display: grid;
+    place-items: center;
+    padding: clamp(18px, 4vw, 28px);
+    margin: 0;
+    background: var(--white);
+    border-radius: clamp(18px, 4vw, 28px);
+    box-shadow: var(--box-shadow);
+    overflow: hidden;
+}
+
+.carousel-item__frame {
+    width: min(100%, var(--carousel-max-visual-width));
+    aspect-ratio: var(--carousel-aspect);
+    border-radius: clamp(16px, 4vw, 26px);
+    overflow: hidden;
+    display: grid;
+    place-items: center;
+    background: var(--white);
 }
 
 .carousel-item img {
-    display: block;
-    width: auto;
-    max-width: 100%;
-    height: auto;
-    max-height: min(70vh, 680px);
+    width: 100%;
+    height: 100%;
     object-fit: contain;
+    object-position: center;
     cursor: zoom-in;
+    border-radius: inherit;
+    transition: transform var(--transition-medium);
+}
+
+.carousel-item--landscape {
+    --carousel-aspect: 3 / 2;
+    --carousel-max-visual-width: min(90vw, 860px);
+    padding: clamp(12px, 3vw, 20px);
+}
+
+.carousel-item--landscape .carousel-item__frame {
     border-radius: clamp(14px, 3.5vw, 24px);
-    background: var(--white);
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
+}
+
+.carousel-item--landscape img {
+    object-fit: cover;
+}
+
+.carousel-item--portrait {
+    --carousel-aspect: 3 / 4;
+    --carousel-max-visual-width: min(76vw, 540px);
+}
+
+.carousel-item--clone {
+    pointer-events: none;
 }
 
 .carousel-control {
@@ -2477,6 +2513,14 @@ footer::before {
         scroll-padding: clamp(16px, 5vw, 24px);
     }
 
+    .carousel-item {
+        --carousel-max-visual-width: min(86vw, 520px);
+    }
+
+    .carousel-item--landscape {
+        --carousel-max-visual-width: min(94vw, 700px);
+    }
+
     .gallery-modal__inner {
         width: min(94vw, 720px);
         grid-template-columns: minmax(0, 1fr);
@@ -2524,7 +2568,12 @@ footer::before {
     }
 
     .carousel-item {
-        min-height: clamp(240px, 58vw, 460px);
+        padding: clamp(16px, 6vw, 24px);
+        --carousel-max-visual-width: min(92vw, 460px);
+    }
+
+    .carousel-item--landscape {
+        --carousel-max-visual-width: min(98vw, 640px);
     }
 
     .carousel-control {
@@ -2548,8 +2597,12 @@ footer::before {
     }
 
     .carousel-item {
-        min-height: clamp(210px, 70vw, 360px);
-        padding: clamp(10px, 5vw, 16px);
+        padding: clamp(14px, 7vw, 20px);
+        --carousel-max-visual-width: min(96vw, 420px);
+    }
+
+    .carousel-item--landscape {
+        --carousel-max-visual-width: min(100vw, 540px);
     }
 
     .gallery-modal__figure figcaption {


### PR DESCRIPTION
## Summary
- give portrait and landscape photos tailored frames so landscape shots display larger with consistent aspect ratios
- wrap slides with reusable frames and orientation classes while syncing clones for seamless styling
- reintroduce infinite carousel scrolling by cloning slides and snapping back to the real items when the loop completes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d4b8ac16cc8330a38dff39acd9b9c2