### PR TITLE
Improve carousel spacing for landscape photos

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2252,7 +2252,7 @@ footer::before {
 .carousel-track {
     position: relative;
     display: flex;
-    gap: clamp(16px, 4vw, 24px);<<<<<< codex/fix-image-spacing-for-landscape-and-portrait
+    gap: clamp(16px, 4vw, 24px);
     align-items: center;
     overflow-x: auto;
     padding: clamp(20px, 4vw, 32px);
@@ -2276,6 +2276,7 @@ footer::before {
 .carousel-item {
     --carousel-aspect: 3 / 4;
     --carousel-max-visual-width: min(78vw, 560px);
+    --carousel-frame-padding: clamp(18px, 4vw, 28px);
     flex: 0 0 100%;
     scroll-snap-align: center;
     display: grid;
@@ -2283,7 +2284,7 @@ footer::before {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: clamp(18px, 4vw, 28px);
+    padding: var(--carousel-frame-padding);
     margin: 0;
     background: var(--white);
     border-radius: clamp(18px, 4vw, 28px);
@@ -2313,8 +2314,8 @@ footer::before {
 
 .carousel-item--landscape {
     --carousel-aspect: 3 / 2;
-    --carousel-max-visual-width: min(90vw, 860px);
-    padding: clamp(12px, 3vw, 20px);
+    --carousel-max-visual-width: min(92vw, 880px);
+    --carousel-frame-padding: clamp(12px, 3vw, 20px);
 }
 
 .carousel-item--landscape .carousel-item__frame {
@@ -2571,8 +2572,8 @@ footer::before {
     }
 
     .carousel-item {
-        padding: clamp(16px, 6vw, 24px);
         --carousel-max-visual-width: min(92vw, 460px);
+        --carousel-frame-padding: clamp(16px, 6vw, 24px);
     }
 
     .carousel-item--landscape {
@@ -2600,8 +2601,8 @@ footer::before {
     }
 
     .carousel-item {
-        padding: clamp(14px, 7vw, 20px);
         --carousel-max-visual-width: min(96vw, 420px);
+        --carousel-frame-padding: clamp(14px, 7vw, 20px);
     }
 
     .carousel-item--landscape {

--- a/js/main.js
+++ b/js/main.js
@@ -655,15 +655,38 @@ document.addEventListener('DOMContentLoaded', function() {
 
             const applyOrientation = () => {
                 const { naturalWidth = 0, naturalHeight = 0 } = image;
-                const isLandscape = naturalWidth >= naturalHeight && naturalWidth > 0;
+                const hasDimensions = naturalWidth > 0 && naturalHeight > 0;
+                const isLandscape = hasDimensions ? naturalWidth >= naturalHeight : item.classList.contains('carousel-item--landscape');
+
+                const aspectRatio = (() => {
+                    if (!hasDimensions) {
+                        return isLandscape ? 3 / 2 : 3 / 4;
+                    }
+                    const rawRatio = naturalWidth / naturalHeight;
+                    const minRatio = isLandscape ? 1 : 0.55;
+                    const maxRatio = isLandscape ? 2.4 : 1.15;
+                    return Math.min(Math.max(rawRatio, minRatio), maxRatio);
+                })();
+
+                const maxWidthValue = isLandscape ? 'min(92vw, 880px)' : 'min(78vw, 560px)';
+                const paddingValue = isLandscape ? 'clamp(12px, 3vw, 20px)' : 'clamp(18px, 4vw, 28px)';
+
+                const applyCustomProperties = target => {
+                    target.style.setProperty('--carousel-aspect', String(aspectRatio));
+                    target.style.setProperty('--carousel-max-visual-width', maxWidthValue);
+                    target.style.setProperty('--carousel-frame-padding', paddingValue);
+                };
+
                 item.classList.toggle('carousel-item--landscape', isLandscape);
                 item.classList.toggle('carousel-item--portrait', !isLandscape);
+                applyCustomProperties(item);
 
                 const clonesForItem = cloneRegistry.get(item);
                 if (clonesForItem && clonesForItem.length) {
                     clonesForItem.forEach(cloneItem => {
                         cloneItem.classList.toggle('carousel-item--landscape', isLandscape);
                         cloneItem.classList.toggle('carousel-item--portrait', !isLandscape);
+                        applyCustomProperties(cloneItem);
                     });
                 }
             };


### PR DESCRIPTION
## Summary
- clamp landscape photo orientation detection to use image aspect ratio
- expose carousel layout properties via CSS custom properties for finer tuning
- reduce excess padding on landscape slides to remove white bands around pictures

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d4c1af0b6c8330adc1bc497e5e994f