### PR TITLE
Prevent carousel controls from shifting when pressed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2339,6 +2339,8 @@ footer::before {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+    -webkit-appearance: none;
+    appearance: none;
     background: var(--primary-color);
     color: var(--white);
     border: none;
@@ -2360,6 +2362,10 @@ footer::before {
 .carousel-control:hover,
 .carousel-control:focus-visible {
     background: var(--secondary-color);
+    transform: translateY(-50%) scale(1.05);
+}
+
+.carousel-control:active {
     transform: translateY(-50%) scale(1.05);
 }
 


### PR DESCRIPTION
## Summary
- remove native browser styling from the carousel controls to keep them from shifting on interaction
- keep the pressed state transform aligned with the hover state so the buttons stay centered while active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4c69a44d8833097268e01bc840b98