### PR TITLE
Remove carousel button shift on interaction

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2362,11 +2362,11 @@ footer::before {
 .carousel-control:hover,
 .carousel-control:focus-visible {
     background: var(--secondary-color);
-    transform: translateY(-50%) scale(1.05);
+    transform: translateY(-50%);
 }
 
 .carousel-control:active {
-    transform: translateY(-50%) scale(1.05);
+    transform: translateY(-50%);
 }
 
 .carousel-control:disabled {


### PR DESCRIPTION
## Summary
- keep the carousel navigation buttons locked in place during interaction by removing the hover/active scale transform that nudged them vertically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4cb592b488330a0e924c0d7b9fb0c