### PR TITLE
Keep gallery modal nav buttons anchored when activated

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2362,11 +2362,11 @@ footer::before {
 .carousel-control:hover,
 .carousel-control:focus-visible {
     background: var(--secondary-color);
-    transform: translateY(-50%) scale(1.05);
+    transform: translateY(-50%);
 }
 
 .carousel-control:active {
-    transform: translateY(-50%) scale(1.05);
+    transform: translateY(-50%);
 }
 
 .carousel-control:disabled {
@@ -2497,12 +2497,14 @@ footer::before {
     cursor: pointer;
     transition: background var(--transition-medium), transform var(--transition-medium);
     font-size: clamp(1.6rem, 1.1rem + 1.2vw, 2.2rem);
+    --gallery-nav-translate-y: 0;
+    transform: translateY(var(--gallery-nav-translate-y));
 }
 
 .gallery-modal__nav:hover,
 .gallery-modal__nav:focus-visible {
     background: rgba(229, 157, 131, 0.8);
-    transform: scale(1.05);
+    transform: translateY(var(--gallery-nav-translate-y)) scale(1.05);
 }
 
 .gallery-modal__nav--prev {
@@ -2541,7 +2543,8 @@ footer::before {
     .gallery-modal__nav {
         position: absolute;
         top: 50%;
-        transform: translateY(-50%);
+        --gallery-nav-translate-y: -50%;
+        transform: translateY(var(--gallery-nav-translate-y));
         z-index: 2;
     }
 


### PR DESCRIPTION
## Summary
- preserve the vertical translate applied to the gallery modal nav controls when hover/focus styles run
- ensure the buttons stay centered while tapped or zoomed by composing the translate with the hover scale

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d4cb592b488330a0e924c0d7b9fb0c