### PR TITLE
Add sitemap.xml for main site pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://artistsoftomorrow.org/</loc>
+  </url>
+  <url>
+    <loc>https://artistsoftomorrow.org/about.html</loc>
+  </url>
+  <url>
+    <loc>https://artistsoftomorrow.org/competition.html</loc>
+  </url>
+  <url>
+    <loc>https://artistsoftomorrow.org/contact.html</loc>
+  </url>
+  <url>
+    <loc>https://artistsoftomorrow.org/founders.html</loc>
+  </url>
+  <url>
+    <loc>https://artistsoftomorrow.org/our-journey.html</loc>
+  </url>
+  <url>
+    <loc>https://artistsoftomorrow.org/privacy.html</loc>
+  </url>
+  <url>
+    <loc>https://artistsoftomorrow.org/support.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a sitemap.xml that lists the main public pages so search engines can discover them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e08cd3371883308a0da6a4a12fe7dc