### PR TITLE
Fix image navigation fallback exclusions

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -8,7 +8,12 @@
   ],
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/images/*.{png,jpg,gif,svg}", "/css/*", "/js/*"]
+    "exclude": [
+      "/images/*.{png,jpg,jpeg,gif,svg}",
+      "/images/**/*.{png,jpg,jpeg,gif,svg}",
+      "/css/*",
+      "/js/*"
+    ]
   },
   "responseOverrides": {
     "404": {


### PR DESCRIPTION
## Summary
- update the Static Web App navigation fallback exclusions to include JPEG assets
- ensure nested image directories such as the competition gallery are also excluded from rewrites so images load

## Testing
- not run (static configuration change)


------
https://chatgpt.com/codex/tasks/task_b_68e091a71c648330ac44e359ee2fa235