### PR TITLE
Restore original copy while keeping SEO metadata

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,9 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>About Us | Artists of Tomorrow</title>
-    <meta name="description" content="Learn about the mission and team behind Artists of Tomorrow">
+    <title>About Artists of Tomorrow | Youth Art Mentorship</title>
+    <meta name="description" content="Discover how Artists of Tomorrow advances art equity for underprivileged youth artists through Nathupur and global partnerships.">
     <link rel="icon" href="images/logo.svg" type="image/svg+xml">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="About Artists of Tomorrow | Youth Art Mentorship">
+    <meta property="og:description" content="Discover how Artists of Tomorrow advances art equity for underprivileged youth artists through Nathupur and global partnerships.">
+    <meta property="og:url" content="https://artistsoftomorrow.org/about.html">
+    <meta property="og:image" content="https://artistsoftomorrow.org/images/logo.svg">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="About Artists of Tomorrow | Youth Art Mentorship">
+    <meta name="twitter:description" content="Discover how Artists of Tomorrow advances art equity for underprivileged youth artists through Nathupur and global partnerships.">
+    <meta name="twitter:image" content="https://artistsoftomorrow.org/images/logo.svg">
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
     

--- a/competition.html
+++ b/competition.html
@@ -3,11 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Competition Details | Artists of Tomorrow</title>
-    <meta name="description" content="Learn about the prompt, rules, and prizes for the Artists of Tomorrow competition">
+    <title>Artists of Tomorrow Youth Art Competition Details</title>
+    <meta name="description" content="Explore rules, prizes, and mentoring for the Artists of Tomorrow youth art competition supporting underprivileged artists in Nathupur, Gurugram.">
     <link rel="icon" href="images/logo.svg" type="image/svg+xml">
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Artists of Tomorrow Youth Art Competition Details">
+    <meta property="og:description" content="Explore rules, prizes, and mentoring for the Artists of Tomorrow youth art competition supporting underprivileged artists in Nathupur, Gurugram.">
+    <meta property="og:url" content="https://artistsoftomorrow.org/competition.html">
+    <meta property="og:image" content="https://artistsoftomorrow.org/images/logo.svg">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Artists of Tomorrow Youth Art Competition Details">
+    <meta name="twitter:description" content="Explore rules, prizes, and mentoring for the Artists of Tomorrow youth art competition supporting underprivileged artists in Nathupur, Gurugram.">
+    <meta name="twitter:image" content="https://artistsoftomorrow.org/images/logo.svg">
 
     <!-- Microsoft Clarity Tracking -->
     <script type="text/javascript">
@@ -24,8 +34,52 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-    
+
       gtag('config', 'G-K8P4HJ9KY3');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Event",
+      "name": "Artists of Tomorrow Youth Art Competition",
+      "description": "An art and writing competition providing mentorship and recognition for underprivileged youth artists in Nathupur and Gurugram.",
+      "eventStatus": "https://schema.org/EventScheduled",
+      "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+      "startDate": "2025-02-01",
+      "endDate": "2025-04-30",
+      "eventSchedule": {
+        "@type": "Schedule",
+        "startDate": "2025-02-01",
+        "endDate": "2025-04-30",
+        "repeatFrequency": "P1Y"
+      },
+      "location": {
+        "@type": "Place",
+        "name": "Government Senior Secondary School, Nathupur",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Gurugram",
+          "addressRegion": "Haryana",
+          "addressCountry": "IN"
+        }
+      },
+      "organizer": {
+        "@type": "Organization",
+        "name": "Artists of Tomorrow",
+        "url": "https://artistsoftomorrow.org/",
+        "email": "info@artistsoftomorrow.org"
+      },
+      "image": "https://artistsoftomorrow.org/images/logo.svg",
+      "audience": {
+        "@type": "Audience",
+        "audienceType": "Students ages 12-18",
+        "geographicArea": {
+          "@type": "AdministrativeArea",
+          "name": "Gurugram, Haryana"
+        }
+      }
+    }
     </script>
 </head>
 <body>

--- a/contact.html
+++ b/contact.html
@@ -3,12 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact Us | Artists of Tomorrow</title>
-    <meta name="description" content="Get in touch with the Artists of Tomorrow team">
+    <title>Contact Artists of Tomorrow Youth Art Team</title>
+    <meta name="description" content="Connect with Artists of Tomorrow about youth art competitions for underprivileged artists in Nathupur, Gurugram, and global partner schools.">
     <link rel="icon" href="images/logo.svg" type="image/svg+xml">
-    
+
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Contact Artists of Tomorrow Youth Art Team">
+    <meta property="og:description" content="Connect with Artists of Tomorrow about youth art competitions for underprivileged artists in Nathupur, Gurugram, and global partner schools.">
+    <meta property="og:url" content="https://artistsoftomorrow.org/contact.html">
+    <meta property="og:image" content="https://artistsoftomorrow.org/images/logo.svg">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Contact Artists of Tomorrow Youth Art Team">
+    <meta name="twitter:description" content="Connect with Artists of Tomorrow about youth art competitions for underprivileged artists in Nathupur, Gurugram, and global partner schools.">
+    <meta name="twitter:image" content="https://artistsoftomorrow.org/images/logo.svg">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -92,7 +102,6 @@
                     <div class="contact-details">
                         <h2>Get In Touch</h2>
                         <p>Have questions about the competition? Interested in supporting our mission? We'd love to hear from you!</p>
-
                         <div class="contact-methods" data-animate-group>
                             <div class="contact-method contact-method--email" data-animate>
                                 <h3>Email</h3>

--- a/founders.html
+++ b/founders.html
@@ -3,12 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Our Founders | Artists of Tomorrow</title>
-    <meta name="description" content="Meet the founders of Artists of Tomorrow and learn about their commitment to creative youth.">
+    <title>Artists of Tomorrow Founders | Youth Art Leaders</title>
+    <meta name="description" content="Meet the Artists of Tomorrow founders empowering underprivileged youth artists through mentorship, storytelling, and competitions.">
     <link rel="icon" href="images/logo.svg" type="image/svg+xml">
 
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Artists of Tomorrow Founders | Youth Art Leaders">
+    <meta property="og:description" content="Meet the Artists of Tomorrow founders empowering underprivileged youth artists through mentorship, storytelling, and competitions.">
+    <meta property="og:url" content="https://artistsoftomorrow.org/founders.html">
+    <meta property="og:image" content="https://artistsoftomorrow.org/images/logo.svg">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Artists of Tomorrow Founders | Youth Art Leaders">
+    <meta name="twitter:description" content="Meet the Artists of Tomorrow founders empowering underprivileged youth artists through mentorship, storytelling, and competitions.">
+    <meta name="twitter:image" content="https://artistsoftomorrow.org/images/logo.svg">
 
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){

--- a/index.html
+++ b/index.html
@@ -3,9 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Artists of Tomorrow | Art Competition</title>
-    <meta name="description" content="Empowering children globally through art and writing competitions">
+    <title>Artists of Tomorrow Youth Art Competition</title>
+    <meta name="description" content="Artists of Tomorrow mentors underprivileged youth artists in Nathupur and Gurugram through global art and writing competitions.">
     <link rel="icon" href="images/logo.svg" type="image/svg+xml">
+
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Artists of Tomorrow Youth Art Competition">
+    <meta property="og:description" content="Artists of Tomorrow mentors underprivileged youth artists in Nathupur and Gurugram through global art and writing competitions.">
+    <meta property="og:url" content="https://artistsoftomorrow.org/">
+    <meta property="og:image" content="https://artistsoftomorrow.org/images/logo.svg">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Artists of Tomorrow Youth Art Competition">
+    <meta name="twitter:description" content="Artists of Tomorrow mentors underprivileged youth artists in Nathupur and Gurugram through global art and writing competitions.">
+    <meta name="twitter:image" content="https://artistsoftomorrow.org/images/logo.svg">
     
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
@@ -21,10 +31,31 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-K8P4HJ9KY3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag(){dataLayer.push(arguments);} 
       gtag('js', new Date());
-    
+
       gtag('config', 'G-K8P4HJ9KY3');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Artists of Tomorrow",
+      "url": "https://artistsoftomorrow.org/",
+      "logo": "https://artistsoftomorrow.org/images/logo.svg",
+      "sameAs": [
+        "https://www.instagram.com/artists.0f.tomorrow/",
+        "https://www.tiktok.com/@artists.of.tomorrow",
+        "https://www.gofundme.com/f/myzxfn-artists-of-tomorrow"
+      ],
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "email": "info@artistsoftomorrow.org",
+        "contactType": "Customer Service"
+      },
+      "description": "Artists of Tomorrow is a youth art competition mentoring underprivileged artists in Nathupur and Gurugram through equitable global art opportunities."
+    }
     </script>
 </head>
 <body>
@@ -73,7 +104,7 @@
                     <span class="hero-title-word hero-title-word--of">of</span>
                     <span class="hero-title-word hero-title-word--tomorrow">Tomorrow</span>
                 </h1>
-                <h2>Empowering Children Through Art & Self-Expression</h2>
+                <h2>Empowering Children Through Art &amp; Self-Expression</h2>
                 <a href="competition.html" class="cta-button">Learn About the Competition</a>
             </div>
             <div class="hero-ornaments" aria-hidden="true">

--- a/support.html
+++ b/support.html
@@ -3,9 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Support Us | Artists of Tomorrow</title>
-    <meta name="description" content="Support Artists of Tomorrow by funding art supplies, programming, and student recognition.">
+    <title>Support Artists of Tomorrow Youth Art Equity</title>
+    <meta name="description" content="Support Artists of Tomorrow by funding supplies, mentoring, and showcases for underprivileged youth artists in Nathupur, Gurugram, and beyond.">
     <link rel="icon" href="images/logo.svg" type="image/svg+xml">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Support Artists of Tomorrow Youth Art Equity">
+    <meta property="og:description" content="Support Artists of Tomorrow by funding supplies, mentoring, and showcases for underprivileged youth artists in Nathupur, Gurugram, and beyond.">
+    <meta property="og:url" content="https://artistsoftomorrow.org/support.html">
+    <meta property="og:image" content="https://artistsoftomorrow.org/images/logo.svg">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Support Artists of Tomorrow Youth Art Equity">
+    <meta name="twitter:description" content="Support Artists of Tomorrow by funding supplies, mentoring, and showcases for underprivileged youth artists in Nathupur, Gurugram, and beyond.">
+    <meta name="twitter:image" content="https://artistsoftomorrow.org/images/logo.svg">
 
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">


### PR DESCRIPTION
## Summary
- revert homepage hero and mission copy to the original wording while keeping the updated SEO metadata in place
- reset about, support, contact, and founders page content to their prior text while retaining the structured and social metadata additions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e57abe071883309db7e425fcb9a633