### PR TITLE
Add Google Fonts to all pages for consistent typography

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,7 +17,10 @@
     <meta name="twitter:image" content="https://artistsoftomorrow.org/images/logo.svg">
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
-    
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
+
     <!-- Microsoft Clarity Tracking -->
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){

--- a/competition.html
+++ b/competition.html
@@ -8,6 +8,9 @@
     <link rel="icon" href="images/logo-favicon.png" type="image/png">
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
 
     <meta property="og:type" content="website">
     <meta property="og:title" content="Artists of Tomorrow Youth Art Competition Details">

--- a/contact.html
+++ b/contact.html
@@ -22,6 +22,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
 
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){

--- a/founders.html
+++ b/founders.html
@@ -9,6 +9,9 @@
 
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
 
     <meta property="og:type" content="website">
     <meta property="og:title" content="Artists of Tomorrow Founders | Youth Art Leaders">

--- a/index.html
+++ b/index.html
@@ -10,11 +10,12 @@
     <meta property="og:image" content="images/logo.svg">
     <meta property="og:url" content="https://artistsoftomorrow.org">
     <!-- Links and Styles -->
+    <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
     <link rel="icon" type="image/x-icon" href="images/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Inter:wght@400;500;600&family=Outfit:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
     <script>
         // Inline script to prevent FOUC and handle interactions before main.js loads
         document.documentElement.className = 'js-loading';

--- a/leaders-of-tomorrow.html
+++ b/leaders-of-tomorrow.html
@@ -22,6 +22,9 @@
 
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
 
     <!-- Microsoft Clarity Tracking -->
     <script type="text/javascript">

--- a/our-journey.html
+++ b/our-journey.html
@@ -9,6 +9,9 @@
 
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
 
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,10 @@
     <link rel="icon" href="images/logo-favicon.png" type="image/png">
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
-    
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
+
     <!-- Microsoft Clarity Tracking -->
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){

--- a/support.html
+++ b/support.html
@@ -18,6 +18,9 @@
 
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap">
 
     <script type="text/javascript">
         (function(c,l,a,r,i,t,y){


### PR DESCRIPTION
## Summary
This PR adds Google Fonts imports across all HTML pages to ensure consistent typography throughout the website. The fonts are now loaded from Google Fonts API with preconnect links for improved performance.

## Key Changes
- Added Google Fonts preconnect links to `https://fonts.googleapis.com` and `https://fonts.gstatic.com` across all pages
- Imported a unified set of fonts: Lato, Newsreader, Playfair Display, and Plus Jakarta Sans with multiple weight variants
- Updated `index.html` to use the new font set (previously used Playfair Display, Inter, and Outfit)
- Applied the same font imports consistently to: `about.html`, `privacy.html`, `competition.html`, `founders.html`, `leaders-of-tomorrow.html`, `our-journey.html`, `support.html`, and `contact.html`
- Added missing `normalize.css` link to `index.html` for consistency

## Implementation Details
- Preconnect links are placed before the stylesheet link to optimize font loading performance
- All pages now use the same font family set with weights: 300, 400, 500, 600, 700 (where applicable per font)
- The `display=swap` parameter ensures text remains visible during font load
- Maintains existing stylesheet structure and load order

https://claude.ai/code/session_01S4qMMTPpKZKdxCP27AVqdb